### PR TITLE
v1.7.2 — fix streams (Twitch hash rotation), Enter-to-send, reliable updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ release notes automatically.
 
 ## 1.7.2 - 2026-06-15
 
-Streams play again.
+Streams play again, chat gets Enter-to-send, and in-app updates install reliably.
+
+### New
+- **Press Enter to send chat.** Send a message with the Enter key instead of clicking the arrow. Tab still completes an emote suggestion, and the arrow button is still there if you prefer it.
 
 ### Fixed
 - **Streams load again.** Twitch changed something on their side that stopped PureTV from starting any stream — the player stayed black and the ad-blocker was stuck on "Checking…". PureTV now asks Twitch for streams in a way that doesn't depend on that, so live channels and past broadcasts play normally again.
+- **Updates install on the first try.** In-app updates often failed the first time (and sometimes the second), and only went through after a few attempts. PureTV now downloads updates over a more reliable connection and retries automatically, so updating works the first time.
 - **Clearer when something's wrong.** If a stream genuinely can't be reached, the ad-block badge no longer hangs on "Checking…" forever, so a real outage is easier to spot.
 
 ## 1.7.1 - 2026-06-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ release notes automatically.
 
 ---
 
+## 1.7.2 - 2026-06-15
+
+Streams play again.
+
+### Fixed
+- **Streams load again.** Twitch changed something on their side that stopped PureTV from starting any stream — the player stayed black and the ad-blocker was stuck on "Checking…". PureTV now asks Twitch for streams in a way that doesn't depend on that, so live channels and past broadcasts play normally again.
+- **Clearer when something's wrong.** If a stream genuinely can't be reached, the ad-block badge no longer hangs on "Checking…" forever, so a real outage is easier to spot.
+
 ## 1.7.1 - 2026-06-15
 
 A quick fix for the new chat.

--- a/app-windows/build.gradle.kts
+++ b/app-windows/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 // ── App version (single source of truth) ─────────────────────────────────────
 // Drives both the MSI `packageVersion` AND the generated AppBuildConfig the
 // in-app updater compares against GitHub Releases — so the two can never drift.
-val appVersion = "1.7.1"
+val appVersion = "1.7.2"
 
 val generateAppBuildConfig by tasks.registering {
     val outDir = layout.buildDirectory.dir("generated/buildconfig/kotlin")

--- a/app-windows/src/main/kotlin/com/puretv/twitch/desktop/player/LocalStreamProxy.kt
+++ b/app-windows/src/main/kotlin/com/puretv/twitch/desktop/player/LocalStreamProxy.kt
@@ -175,6 +175,11 @@ class LocalStreamProxy(
                         }
                     }.onFailure { e ->
                         failures.incrementAndGet()
+                        // Resolution threw before resolveCleanStream could run (e.g. the
+                        // GQL token mint failed). resolveCleanStream never set a status, so
+                        // flip the engine off UNKNOWN here — otherwise the pill hangs on
+                        // "Checking…" forever and hides the outage (GOTCHA #1 lesson).
+                        adBlockEngine.reportResolutionFailure()
                         lastFailure.set(
                             FetchSnapshot(
                                 channel = channel,

--- a/app-windows/src/main/kotlin/com/puretv/twitch/desktop/ui/chat/ChatComposerLogic.kt
+++ b/app-windows/src/main/kotlin/com/puretv/twitch/desktop/ui/chat/ChatComposerLogic.kt
@@ -33,3 +33,19 @@ fun insertAtCursor(text: String, cursor: Int, code: String): Pair<String, Int> {
     val ins = (if (needsLead) " " else "") + code + " "
     return (text.substring(0, at) + ins + text.substring(at)) to (at + ins.length)
 }
+
+/** What a key press in the chat composer should do. */
+enum class ComposerKeyAction { SEND, COMPLETE, NONE }
+
+/**
+ * Maps a composer key press to an action. Enter sends (matching Twitch's web
+ * client, and what users expect instead of clicking the arrow); Tab accepts the
+ * first emote suggestion only when one is offered; anything else falls through
+ * to normal text editing. Enter wins over Tab even while the autocomplete strip
+ * is open — Tab is the completion key, Enter is always "send".
+ */
+fun composerKeyAction(isEnter: Boolean, isTab: Boolean, hasSuggestions: Boolean): ComposerKeyAction = when {
+    isEnter -> ComposerKeyAction.SEND
+    isTab && hasSuggestions -> ComposerKeyAction.COMPLETE
+    else -> ComposerKeyAction.NONE
+}

--- a/app-windows/src/main/kotlin/com/puretv/twitch/desktop/ui/screens/StreamContent.kt
+++ b/app-windows/src/main/kotlin/com/puretv/twitch/desktop/ui/screens/StreamContent.kt
@@ -93,7 +93,9 @@ import com.puretv.twitch.desktop.ui.components.AdBlockPill
 import com.puretv.twitch.desktop.ui.components.ChatMessageRow
 import com.puretv.twitch.desktop.ui.components.LiveDot
 import com.puretv.twitch.desktop.ui.components.SegmentedControl
+import com.puretv.twitch.desktop.ui.chat.ComposerKeyAction
 import com.puretv.twitch.desktop.ui.chat.completeWord
+import com.puretv.twitch.desktop.ui.chat.composerKeyAction
 import com.puretv.twitch.desktop.ui.chat.insertAtCursor
 import com.puretv.twitch.desktop.ui.chat.matchEmotes
 import com.puretv.twitch.desktop.ui.chat.nextUnread
@@ -714,13 +716,15 @@ private fun ChatInputBar(
                             fieldFocused = it.isFocused
                             onFocusChanged(it.isFocused)
                         }
-                        // Tab accepts the first emote suggestion when one is offered.
+                        // Enter sends the message; Tab accepts the first emote
+                        // suggestion when one is offered (see composerKeyAction).
                         .onPreviewKeyEvent { ev ->
-                            if (ev.key == Key.Tab && ev.type == KeyEventType.KeyDown && suggestions.isNotEmpty()) {
-                                applyCompletion(suggestions.first().code)
-                                true
-                            } else {
-                                false
+                            if (ev.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                            val isEnter = ev.key == Key.Enter || ev.key == Key.NumPadEnter
+                            when (composerKeyAction(isEnter, ev.key == Key.Tab, suggestions.isNotEmpty())) {
+                                ComposerKeyAction.SEND -> { submit(); true }
+                                ComposerKeyAction.COMPLETE -> { applyCompletion(suggestions.first().code); true }
+                                ComposerKeyAction.NONE -> false
                             }
                         },
                 )

--- a/app-windows/src/main/kotlin/com/puretv/twitch/desktop/update/UpdateManager.kt
+++ b/app-windows/src/main/kotlin/com/puretv/twitch/desktop/update/UpdateManager.kt
@@ -38,6 +38,14 @@ class UpdateManager {
     private val json = Json { ignoreUnknownKeys = true }
     private val http = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(10))
+        // Force HTTP/1.1. The JDK client defaults to HTTP/2, and GitHub's API +
+        // asset CDN recycle h2 connections aggressively (GOAWAY). The client will
+        // reuse a pooled connection the server has already half-closed and throw
+        // IOException ("GOAWAY received" / "EOF reached") on the NEXT request —
+        // the root cause of "the first download attempt errors, a retry works".
+        // HTTP/1.1 avoids the stale-h2-connection failure mode entirely; the
+        // retry below handles any remaining transient blips.
+        .version(HttpClient.Version.HTTP_1_1)
         // A GitHub release asset URL (browser_download_url) does NOT serve the
         // file: it 302-redirects to a short-lived signed release-assets.github
         // usercontent.com URL. The JDK HttpClient defaults to Redirect.NEVER,
@@ -78,7 +86,13 @@ class UpdateManager {
             .timeout(Duration.ofSeconds(15))
             .GET()
             .build()
-        val response = http.send(request, HttpResponse.BodyHandlers.ofString())
+        val response = withUpdateRetry {
+            val r = http.send(request, HttpResponse.BodyHandlers.ofString())
+            // 5xx is a transient GitHub hiccup worth retrying; 4xx (e.g. rate
+            // limit) is not and falls through to the null-handling below.
+            if (r.statusCode() in 500..599) throw TransientUpdateException("GitHub API ${r.statusCode()}")
+            r
+        }
         if (response.statusCode() != 200) return@withContext null
         val release = json.decodeFromString(GithubRelease.serializer(), response.body())
         if (release.draft || release.prerelease) return@withContext null
@@ -121,30 +135,42 @@ class UpdateManager {
         val ext = if (info.downloadUrl.endsWith(".exe", ignoreCase = true)) "exe" else "msi"
         val target = File(dir, "PureTV-${info.version}.$ext")
 
-        val request = HttpRequest.newBuilder(URI.create(info.downloadUrl))
-            .header("User-Agent", "PureTV-Updater")
-            .GET()
-            .build()
-        val response = http.send(request, HttpResponse.BodyHandlers.ofInputStream())
-        if (response.statusCode() !in 200..299) error("Download failed (HTTP ${response.statusCode()})")
+        // Retry the whole download: a stale connection, reset, or truncation
+        // throws a transient error and we re-attempt from scratch (the file is
+        // re-opened/truncated each time) instead of erroring out to the user.
+        withUpdateRetry {
+            val request = HttpRequest.newBuilder(URI.create(info.downloadUrl))
+                .header("User-Agent", "PureTV-Updater")
+                // Bounds connect + time-to-first-byte so a hung start fails into
+                // a retry rather than hanging the download forever.
+                .timeout(Duration.ofMinutes(5))
+                .GET()
+                .build()
+            val response = http.send(request, HttpResponse.BodyHandlers.ofInputStream())
+            if (response.statusCode() !in 200..299) {
+                throw TransientUpdateException("Download failed (HTTP ${response.statusCode()})")
+            }
 
-        response.body().use { input ->
-            target.outputStream().use { output ->
-                val buffer = ByteArray(64 * 1024)
-                var total = 0L
-                while (true) {
-                    val read = input.read(buffer)
-                    if (read < 0) break
-                    output.write(buffer, 0, read)
-                    total += read
-                    if (info.sizeBytes > 0) {
-                        _state.value = UpdateState.Downloading((total.toFloat() / info.sizeBytes).coerceIn(0f, 1f))
+            response.body().use { input ->
+                target.outputStream().use { output ->
+                    val buffer = ByteArray(64 * 1024)
+                    var total = 0L
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        total += read
+                        if (info.sizeBytes > 0) {
+                            _state.value = UpdateState.Downloading((total.toFloat() / info.sizeBytes).coerceIn(0f, 1f))
+                        }
                     }
                 }
             }
+            if (info.sizeBytes > 0 && target.length() != info.sizeBytes) {
+                throw TransientUpdateException("Download incomplete (${target.length()}/${info.sizeBytes} bytes)")
+            }
+            target
         }
-        if (info.sizeBytes > 0 && target.length() != info.sizeBytes) error("Download incomplete — please retry")
-        target
     }
 
     /**
@@ -175,14 +201,19 @@ class UpdateManager {
         }
     }
 
-    private fun downloadText(url: String): String {
+    private suspend fun downloadText(url: String): String = withUpdateRetry {
         val request = HttpRequest.newBuilder(URI.create(url))
             .header("User-Agent", "PureTV-Updater")
+            .timeout(Duration.ofSeconds(30))
             .GET()
             .build()
         val response = http.send(request, HttpResponse.BodyHandlers.ofString())
-        if (response.statusCode() !in 200..299) error("Signature download failed (HTTP ${response.statusCode()})")
-        return response.body()
+        // Transient so a stale-connection blip on the signature fetch (right
+        // after the big download) retries instead of failing the whole update.
+        if (response.statusCode() !in 200..299) {
+            throw TransientUpdateException("Signature download failed (HTTP ${response.statusCode()})")
+        }
+        response.body()
     }
 
     private fun launchInstaller(installer: File) {

--- a/app-windows/src/main/kotlin/com/puretv/twitch/desktop/update/UpdateRetry.kt
+++ b/app-windows/src/main/kotlin/com/puretv/twitch/desktop/update/UpdateRetry.kt
@@ -1,0 +1,53 @@
+package com.puretv.twitch.desktop.update
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import java.io.IOException
+import java.net.http.HttpTimeoutException
+
+/**
+ * A transient update failure a fresh attempt might fix: a truncated download, a
+ * retryable HTTP status, etc. Distinct from fatal failures (bad signature, no
+ * signing key) which must never be retried.
+ */
+class TransientUpdateException(message: String) : Exception(message)
+
+/**
+ * Classifies a failure as worth retrying. Network-level faults (connection
+ * reset, EOF/GOAWAY from a stale HTTP/2 connection, timeouts) are transient;
+ * cancellation and logic/security errors (e.g. a failed signature check, raised
+ * as [IllegalStateException]) are not.
+ */
+internal fun isTransientUpdateError(e: Throwable): Boolean = when (e) {
+    is CancellationException -> false
+    is TransientUpdateException -> true
+    is HttpTimeoutException -> true
+    is IOException -> true
+    else -> false
+}
+
+/**
+ * Runs [block], retrying transient failures (per [isTransient]) up to
+ * [maxAttempts] total with exponential backoff (baseDelayMs, then doubling).
+ * A non-transient failure is re-thrown immediately (fail-closed); once attempts
+ * are exhausted the last transient failure is re-thrown. [sleep] is injectable
+ * so tests run without real delays.
+ */
+internal suspend fun <T> withUpdateRetry(
+    maxAttempts: Int = 3,
+    baseDelayMs: Long = 400,
+    isTransient: (Throwable) -> Boolean = ::isTransientUpdateError,
+    sleep: suspend (Long) -> Unit = { delay(it) },
+    block: suspend () -> T,
+): T {
+    var attempt = 1
+    while (true) {
+        try {
+            return block()
+        } catch (e: Throwable) {
+            if (!isTransient(e) || attempt >= maxAttempts) throw e
+            sleep(baseDelayMs shl (attempt - 1)) // 400ms, 800ms, 1600ms…
+            attempt++
+        }
+    }
+}

--- a/app-windows/src/test/kotlin/com/puretv/twitch/desktop/ui/chat/ChatComposerLogicTest.kt
+++ b/app-windows/src/test/kotlin/com/puretv/twitch/desktop/ui/chat/ChatComposerLogicTest.kt
@@ -119,4 +119,24 @@ class ChatComposerLogicTest {
         assertEquals("hi Kappa  there", text)
         assertEquals(9, cursor)
     }
+
+    // ── composerKeyAction (Enter-to-send) ─────────────────────────────────────────
+
+    @Test fun enterSendsTheMessage() {
+        assertEquals(ComposerKeyAction.SEND, composerKeyAction(isEnter = true, isTab = false, hasSuggestions = false))
+    }
+
+    @Test fun enterSendsEvenWhileAutocompleteIsOpen() {
+        // Twitch parity: Tab accepts a suggestion, Enter still sends.
+        assertEquals(ComposerKeyAction.SEND, composerKeyAction(isEnter = true, isTab = false, hasSuggestions = true))
+    }
+
+    @Test fun tabCompletesOnlyWhenSuggestionsExist() {
+        assertEquals(ComposerKeyAction.COMPLETE, composerKeyAction(isEnter = false, isTab = true, hasSuggestions = true))
+        assertEquals(ComposerKeyAction.NONE, composerKeyAction(isEnter = false, isTab = true, hasSuggestions = false))
+    }
+
+    @Test fun otherKeysDoNothingSpecial() {
+        assertEquals(ComposerKeyAction.NONE, composerKeyAction(isEnter = false, isTab = false, hasSuggestions = true))
+    }
 }

--- a/app-windows/src/test/kotlin/com/puretv/twitch/desktop/update/UpdateRetryTest.kt
+++ b/app-windows/src/test/kotlin/com/puretv/twitch/desktop/update/UpdateRetryTest.kt
@@ -1,0 +1,67 @@
+package com.puretv.twitch.desktop.update
+
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The retry core behind the reliable in-app updater. The old updater made each
+ * GitHub request exactly once, so a single transient blip (stale HTTP/2
+ * connection / GOAWAY / truncated read) surfaced as a hard error and the user
+ * had to retry by hand. This helper does that retry automatically — while still
+ * failing closed on non-transient errors (a failed signature check must NOT be
+ * retried into a "success").
+ */
+class UpdateRetryTest {
+
+    private val noSleep: suspend (Long) -> Unit = {}
+
+    @Test fun returnsImmediatelyOnFirstSuccess() = runBlocking {
+        var calls = 0
+        val result = withUpdateRetry(maxAttempts = 3, sleep = noSleep) { calls++; "ok" }
+        assertEquals("ok", result)
+        assertEquals(1, calls)
+    }
+
+    @Test fun retriesTransientFailureThenSucceeds() = runBlocking {
+        var calls = 0
+        val result = withUpdateRetry(maxAttempts = 3, sleep = noSleep) {
+            calls++
+            if (calls < 3) throw TransientUpdateException("connection blip")
+            "recovered"
+        }
+        assertEquals("recovered", result)
+        assertEquals(3, calls)
+    }
+
+    @Test fun givesUpAfterMaxAttemptsAndRethrowsLast() = runBlocking {
+        var calls = 0
+        assertFailsWith<TransientUpdateException> {
+            withUpdateRetry(maxAttempts = 3, sleep = noSleep) {
+                calls++; throw TransientUpdateException("always down")
+            }
+        }
+        assertEquals(3, calls)
+    }
+
+    @Test fun doesNotRetryNonTransientFailure() = runBlocking {
+        // A failed signature check / "not signed" is fatal — retrying it would be
+        // a security regression. It must surface on the first attempt.
+        var calls = 0
+        assertFailsWith<IllegalStateException> {
+            withUpdateRetry(maxAttempts = 3, sleep = noSleep) {
+                calls++; error("signature check FAILED")
+            }
+        }
+        assertEquals(1, calls)
+    }
+
+    @Test fun classifiesNetworkBlipsAsTransientButNotLogicErrors() {
+        assertTrue(isTransientUpdateError(java.io.IOException("GOAWAY received")))
+        assertTrue(isTransientUpdateError(TransientUpdateException("truncated")))
+        assertFalse(isTransientUpdateError(IllegalStateException("not signed")))
+    }
+}

--- a/core/src/commonMain/kotlin/com/puretv/twitch/core/adblock/AdBlockEngine.kt
+++ b/core/src/commonMain/kotlin/com/puretv/twitch/core/adblock/AdBlockEngine.kt
@@ -100,6 +100,19 @@ class AdBlockEngine(
      */
     fun filterPlaylist(playlistContent: String): FilteredPlaylist = rewriter.filter(playlistContent)
 
+    /**
+     * Called by the transport layer (e.g. `LocalStreamProxy`) when stream
+     * resolution fails BEFORE [resolveCleanStream] can run — typically the GQL
+     * playback-token mint threw (a banned/renamed channel, or Twitch changing
+     * the API as in GOTCHA #1). Without this the status would sit at
+     * [AdBlockStatus.UNKNOWN] ("Checking…") forever, silently masking the
+     * outage; moving it to [AdBlockStatus.AD_BLOCK_OFF] makes the failure
+     * visible in the on-screen pill instead.
+     */
+    fun reportResolutionFailure() {
+        _status.value = AdBlockStatus.AD_BLOCK_OFF
+    }
+
     // ---- Strategy 1: Proxy Router ----
 
     /**

--- a/core/src/commonMain/kotlin/com/puretv/twitch/core/api/TwitchConfig.kt
+++ b/core/src/commonMain/kotlin/com/puretv/twitch/core/api/TwitchConfig.kt
@@ -40,13 +40,11 @@ object TwitchConfig {
      */
     const val GQL_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko"
 
-    /**
-     * Persisted-query hash for the PlaybackAccessToken GQL operation.
-     * Twitch rotates this occasionally — see [com.puretv.twitch.core.stream.GqlHashProvider]
-     * for the dynamic-refresh strategy that should back this constant up.
-     */
-    const val PLAYBACK_ACCESS_TOKEN_HASH =
-        "0828119ded1c13477966434e15800ff57ddacf13ba1911c129dc2200705b0712"
+    // NOTE: the PlaybackAccessToken operation is sent as a FULL INLINE GraphQL
+    // query (see com.puretv.twitch.core.stream.PLAYBACK_ACCESS_TOKEN_QUERY), not
+    // a persisted-query sha256Hash. Twitch rotates persisted hashes without
+    // notice — a stale hash returns PersistedQueryNotFound and breaks all stream
+    // resolution (GOTCHA #1). The inline query has no hash to invalidate.
 
     const val USHER_BASE = "https://usher.ttvnw.net/api/channel/hls"
     const val USHER_VOD_BASE = "https://usher.ttvnw.net/vod"

--- a/core/src/commonMain/kotlin/com/puretv/twitch/core/di/CoreModule.kt
+++ b/core/src/commonMain/kotlin/com/puretv/twitch/core/di/CoreModule.kt
@@ -10,7 +10,6 @@ import com.puretv.twitch.core.repository.ChannelRepository
 import com.puretv.twitch.core.repository.ChannelStatsRepository
 import com.puretv.twitch.core.repository.StreamRepository
 import com.puretv.twitch.core.repository.UserRepository
-import com.puretv.twitch.core.stream.GqlHashProvider
 import com.puretv.twitch.core.stream.StreamResolver
 import com.puretv.twitch.core.stream.TwitchGqlClient
 import io.ktor.client.HttpClient
@@ -36,8 +35,7 @@ val coreModule = module {
 
     // Twitch
     single { val holder = get<TokenHolder>(); TwitchApiClient(get()) { holder.current() } }
-    single { GqlHashProvider() }
-    single { TwitchGqlClient(get(), get()) }
+    single { TwitchGqlClient(get()) }
     single { StreamResolver(get(), get()) }
 
     // Ad Block — AdBlockConfig is normally provided per-platform from DataStore/settings;

--- a/core/src/commonMain/kotlin/com/puretv/twitch/core/stream/TwitchGqlClient.kt
+++ b/core/src/commonMain/kotlin/com/puretv/twitch/core/stream/TwitchGqlClient.kt
@@ -18,16 +18,18 @@ import kotlinx.serialization.json.Json
 /**
  * SECTION 03.4 [CRITICAL] — Helix does not expose a playable stream URL.
  * The only way to obtain one is the undocumented GraphQL `PlaybackAccessToken`
- * persisted query, which returns a signed token that authorizes a single
+ * operation, which returns a signed token that authorizes a single
  * usher.ttvnw.net master-playlist fetch.
  *
- * GOTCHA #1 (Section 14): Twitch occasionally rotates [TwitchConfig.PLAYBACK_ACCESS_TOKEN_HASH].
- * If this starts returning 400/403, refresh the hash from Twitch's web client bundle —
- * see [GqlHashProvider] for the dynamic-lookup strategy this client falls back to.
+ * GOTCHA #1 (Section 14): we send the FULL inline query
+ * ([PLAYBACK_ACCESS_TOKEN_QUERY]) rather than a persisted-query `sha256Hash`.
+ * Twitch rotates persisted-query hashes without notice — a stale hash returns
+ * `PersistedQueryNotFound`, which surfaced as "streams won't load / ad-block
+ * stuck on Checking…". The inline query carries the operation itself, so there
+ * is no hash for Twitch to invalidate.
  */
 class TwitchGqlClient(
     private val httpClient: HttpClient,
-    private val hashProvider: GqlHashProvider = GqlHashProvider(),
     // encodeDefaults = true is LOAD-BEARING: Twitch's GraphQL schema requires
     // isLive/vodID/isVod/playerType as non-null types. With the kotlinx-serialization
     // default of false, our PlaybackAccessTokenVariables data class's default
@@ -48,10 +50,7 @@ class TwitchGqlClient(
         oauthToken: String?,
         playerType: String = "site",
     ): StreamToken {
-        val hash = hashProvider.currentHash()
-        val response = postPersistedQuery(
-            operationName = "PlaybackAccessToken",
-            hash = hash,
+        val response = postPlaybackAccessToken(
             variables = PlaybackAccessTokenVariables(login = channelLogin, playerType = playerType),
             oauthToken = oauthToken,
         )
@@ -59,15 +58,11 @@ class TwitchGqlClient(
         val payload = json.decodeFromString<GqlEnvelope<PlaybackAccessTokenData>>(response)
         val token = payload.data?.streamPlaybackAccessToken
             ?: run {
-                // Hash likely stale — record the failure so GqlHashProvider can
-                // attempt a dynamic refresh on the next call. Surface the raw
-                // GQL body so the real cause (error message, integrity check,
-                // banned channel, etc.) is visible instead of a generic blame.
-                hashProvider.reportFailure(hash)
+                // Surface the raw GQL body so the real cause (schema change,
+                // integrity check, banned channel, etc.) is visible instead of
+                // a generic blame.
                 val truncated = if (response.length > 600) response.substring(0, 600) + "…" else response
-                throw GqlPlaybackTokenException(
-                    "PlaybackAccessToken returned no token. Hash=$hash. GQL response: $truncated",
-                )
+                throw GqlPlaybackTokenException("PlaybackAccessToken returned no token. GQL response: $truncated")
             }
 
         return StreamToken(value = token.value, signature = token.signature)
@@ -75,10 +70,7 @@ class TwitchGqlClient(
 
     /** Fetch a playback token for a VOD instead of a live channel. */
     suspend fun fetchVodToken(vodId: String, oauthToken: String?): StreamToken {
-        val hash = hashProvider.currentHash()
-        val response = postPersistedQuery(
-            operationName = "PlaybackAccessToken",
-            hash = hash,
+        val response = postPlaybackAccessToken(
             variables = PlaybackAccessTokenVariables(login = "", isLive = false, isVod = true, vodID = vodId),
             oauthToken = oauthToken,
         )
@@ -131,36 +123,59 @@ class TwitchGqlClient(
         return parseFollowerCount(response)
     }
 
-    private suspend fun postPersistedQuery(
-        operationName: String,
-        hash: String,
+    private suspend fun postPlaybackAccessToken(
         variables: PlaybackAccessTokenVariables,
         oauthToken: String?,
-    ): String {
-        val body = GqlPersistedQueryRequest(
-            operationName = operationName,
-            variables = variables,
-            extensions = GqlExtensions(persistedQuery = PersistedQuery(version = 1, sha256Hash = hash)),
-        )
-        return httpClient.post(TwitchConfig.GQL_ENDPOINT) {
-            header("Client-ID", TwitchConfig.GQL_CLIENT_ID)
-            oauthToken?.let { header("Authorization", "OAuth $it") }
-            contentType(ContentType.Application.Json)
-            setBody(json.encodeToString(body))
-        }.body()
-    }
+    ): String = httpClient.post(TwitchConfig.GQL_ENDPOINT) {
+        header("Client-ID", TwitchConfig.GQL_CLIENT_ID)
+        oauthToken?.let { header("Authorization", "OAuth $it") }
+        contentType(ContentType.Application.Json)
+        setBody(buildPlaybackAccessTokenBody(variables, json))
+    }.body()
 }
 
 class GqlPlaybackTokenException(message: String) : Exception(message)
 
-// ---- Wire format for the persisted-query POST body ----
+/**
+ * The FULL inline PlaybackAccessToken GraphQL operation (the same one Twitch's
+ * own web client runs). We send this verbatim instead of a persisted-query
+ * `sha256Hash` so there is nothing for Twitch to rotate out from under us —
+ * the cause of GOTCHA #1 (a stale hash → `PersistedQueryNotFound` → no token →
+ * no stream). The `@include(if:)` directives let the single operation serve
+ * both live (`isLive`) and VOD (`isVod`) requests.
+ */
+internal const val PLAYBACK_ACCESS_TOKEN_QUERY =
+    "query PlaybackAccessToken_Template(\$login: String!, \$isLive: Boolean!, \$vodID: ID!, \$isVod: Boolean!, \$playerType: String!) { " +
+        "streamPlaybackAccessToken(channelName: \$login, params: {platform: \"web\", playerBackend: \"mediaplayer\", playerType: \$playerType}) @include(if: \$isLive) { value signature __typename } " +
+        "videoPlaybackAccessToken(id: \$vodID, params: {platform: \"web\", playerBackend: \"mediaplayer\", playerType: \$playerType}) @include(if: \$isVod) { value signature __typename } }"
 
 @Serializable
-data class GqlPersistedQueryRequest(
+internal data class GqlInlineQueryRequest(
     val operationName: String,
+    val query: String,
     val variables: PlaybackAccessTokenVariables,
-    val extensions: GqlExtensions,
 )
+
+/**
+ * Serializes the PlaybackAccessToken request body. Pure (no network) so the
+ * inline-query contract is unit-testable.
+ *
+ * `encodeDefaults = true` is LOAD-BEARING: Twitch's schema types
+ * isLive/isVod/vodID/playerType as non-null, so the data class defaults must be
+ * serialized — otherwise Twitch sees explicit nulls and rejects the query.
+ */
+internal fun buildPlaybackAccessTokenBody(
+    variables: PlaybackAccessTokenVariables,
+    json: Json = Json { encodeDefaults = true },
+): String = json.encodeToString(
+    GqlInlineQueryRequest(
+        operationName = "PlaybackAccessToken_Template",
+        query = PLAYBACK_ACCESS_TOKEN_QUERY,
+        variables = variables,
+    ),
+)
+
+// ---- Wire format for the PlaybackAccessToken POST body ----
 
 @Serializable
 data class PlaybackAccessTokenVariables(
@@ -170,12 +185,6 @@ data class PlaybackAccessTokenVariables(
     val vodID: String = "",
     val playerType: String = "site",
 )
-
-@Serializable
-data class GqlExtensions(val persistedQuery: PersistedQuery)
-
-@Serializable
-data class PersistedQuery(val version: Int, val sha256Hash: String)
 
 // ---- Response envelope ----
 
@@ -225,37 +234,3 @@ internal fun parseFollowerCount(response: String): Long? =
         followerCountJson.decodeFromString<GqlEnvelope<FollowerCountData>>(response)
             .data?.user?.followers?.totalCount
     }.getOrNull()
-
-/**
- * Holds the persisted-query hash and provides a refresh hook for GOTCHA #1.
- *
- * In production this should periodically scrape Twitch's web client JS bundle
- * for the current `PlaybackAccessToken` sha256Hash (it's a stable string literal
- * in the minified bundle) and cache the result, falling back to the pinned
- * constant when scraping fails or is disabled by the user.
- */
-class GqlHashProvider(
-    private var cachedHash: String = TwitchConfig.PLAYBACK_ACCESS_TOKEN_HASH,
-    private val onFailureRefresh: (suspend () -> String?)? = null,
-) {
-    private var consecutiveFailures = 0
-
-    fun currentHash(): String = cachedHash
-
-    fun reportFailure(failedHash: String) {
-        if (failedHash == cachedHash) consecutiveFailures++
-    }
-
-    /** Call from a background worker if [reportFailure] indicates the pinned hash is stale. */
-    suspend fun tryRefresh(): Boolean {
-        val refreshed = onFailureRefresh?.invoke() ?: return false
-        if (refreshed.isNotBlank() && refreshed != cachedHash) {
-            cachedHash = refreshed
-            consecutiveFailures = 0
-            return true
-        }
-        return false
-    }
-
-    fun shouldAttemptRefresh(): Boolean = consecutiveFailures >= 1
-}

--- a/core/src/commonTest/kotlin/com/puretv/twitch/core/stream/PlaybackAccessTokenRequestTest.kt
+++ b/core/src/commonTest/kotlin/com/puretv/twitch/core/stream/PlaybackAccessTokenRequestTest.kt
@@ -1,0 +1,41 @@
+package com.puretv.twitch.core.stream
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks in the GOTCHA #1 fix: the PlaybackAccessToken request must send the
+ * FULL inline GraphQL query, never a persisted-query hash. Twitch rotated the
+ * pinned `sha256Hash`, which made every persisted request come back
+ * `PersistedQueryNotFound` → no token → no stream. An inline query carries the
+ * operation itself, so there is no hash for Twitch to invalidate.
+ */
+class PlaybackAccessTokenRequestTest {
+
+    @Test fun sendsInlineQueryNotAPersistedHash() {
+        val body = buildPlaybackAccessTokenBody(
+            PlaybackAccessTokenVariables(login = "twitch", playerType = "popout"),
+        )
+
+        // The operation itself must be in the body...
+        assertTrue("streamPlaybackAccessToken" in body, "must inline the live-token query")
+        assertTrue("videoPlaybackAccessToken" in body, "must inline the VOD-token query")
+        // ...and there must be NO rotatable persisted-query hash.
+        assertFalse("persistedQuery" in body, "must not depend on a persisted-query hash")
+        assertFalse("sha256Hash" in body, "must not pin a rotatable hash")
+    }
+
+    @Test fun encodesDefaultValuedVariablesSoTwitchDoesNotSeeNulls() {
+        // encodeDefaults is load-bearing: Twitch's schema types isLive/isVod/
+        // vodID/playerType as non-null, so stripping the defaults makes Twitch
+        // reject the query with "Expected type X!, found null".
+        val body = buildPlaybackAccessTokenBody(
+            PlaybackAccessTokenVariables(login = "twitch", playerType = "popout"),
+        )
+        assertTrue("\"isLive\":true" in body, "isLive default must be serialized")
+        assertTrue("\"isVod\":false" in body, "isVod default must be serialized")
+        assertTrue("\"login\":\"twitch\"" in body)
+        assertTrue("\"playerType\":\"popout\"" in body)
+    }
+}

--- a/core/src/desktopTest/kotlin/com/puretv/twitch/core/adblock/AdBlockEngineResilienceTest.kt
+++ b/core/src/desktopTest/kotlin/com/puretv/twitch/core/adblock/AdBlockEngineResilienceTest.kt
@@ -1,0 +1,34 @@
+package com.puretv.twitch.core.adblock
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Resilience guard for the GOTCHA #1 outage: when stream resolution fails
+ * BEFORE the ad-block engine runs (e.g. the GQL playback-token mint throws),
+ * the status must NOT sit at UNKNOWN ("Checking…") forever — that silent state
+ * is exactly what masked the broken-hash outage. A reported failure must move
+ * the pill to a visible failure state.
+ */
+class AdBlockEngineResilienceTest {
+
+    private fun engine() = AdBlockEngine(AdBlockConfig(), HttpClient(OkHttp))
+
+    @Test fun startsInCheckingState() {
+        assertEquals(AdBlockStatus.UNKNOWN, engine().status.value)
+    }
+
+    @Test fun reportedResolutionFailureLeavesCheckingState() {
+        val e = engine()
+        e.reportResolutionFailure()
+        assertNotEquals(
+            AdBlockStatus.UNKNOWN,
+            e.status.value,
+            "a resolution failure must move the pill off 'Checking…' so the outage is visible",
+        )
+        assertEquals(AdBlockStatus.AD_BLOCK_OFF, e.status.value)
+    }
+}


### PR DESCRIPTION
Ships **v1.7.2** with three changes, all verified locally (core + desktop tests green; the stream fix verified against live Twitch).

## 1. Fix: streams won't load / ad-block stuck on "Checking…" (critical)
Twitch rotated the pinned `PlaybackAccessToken` persisted-query hash → every token mint returned `PersistedQueryNotFound` → no stream, pill stuck on `UNKNOWN`, VLC got a 500. The resolution code was byte-identical to the last working release — this was environmental, not the v1.7.x work.

- Send the **full inline GraphQL query** instead of a persisted-query hash (no hash for Twitch to rotate; verified live to return a signed token). Fixes live + VOD + ad-block backup-swap.
- Removed the dead `GqlHashProvider`, persisted-query types, and `PLAYBACK_ACCESS_TOKEN_HASH`.
- Resilience: `AdBlockEngine.reportResolutionFailure()` moves the pill off "Checking…" so an outage is visible instead of hanging silently.

## 2. Feat: Enter-to-send in the desktop chat composer
Enter (and NumPad Enter) sends; Tab still completes an emote suggestion; the arrow stays for mouse users. Pure `composerKeyAction()` helper, unit-tested.

## 3. Fix: in-app updates fail the first try
Root cause: each GitHub request ran once over an HTTP/2 client; GitHub recycles h2 connections (GOAWAY) and the JDK client reused half-closed ones → `IOException` on the first attempt, manual retry worked.

- Force **HTTP/1.1** on the updater client (removes the stale-connection failure mode).
- **Retry-with-backoff** around metadata/installer/signature fetches; truncated/non-2xx downloads retry automatically.
- Signature **verification stays outside** the retry — a tampered download still fails closed.

## Tests
TDD throughout: `PlaybackAccessTokenRequestTest`, `AdBlockEngineResilienceTest`, `ChatComposerLogicTest` (Enter-to-send), `UpdateRetryTest`. Android/TV targets need the SDK (not installed locally) — this PR's CI validates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
