### PR TITLE
Add Android APK to releases + Windows/Android download buttons; tidy scratch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,47 @@ jobs:
           path: app-windows/build/installer/*.exe
           if-no-files-found: error
 
+  android:
+    name: Android phone app (APK)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Cache Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      # No release keystore is wired yet (app-android/build.gradle.kts leaves the
+      # release signingConfig commented out), so we publish the DEBUG-signed APK:
+      # it sideloads like any app from outside the Play Store. For a production,
+      # Play-updatable build, add a stable keystore (ANDROID_KEYSTORE_BASE64 +
+      # ANDROID_KEYSTORE_PASSWORD / KEY_ALIAS / KEY_PASSWORD), wire signingConfigs
+      # in app-android/build.gradle.kts, and switch this to :app-android:assembleRelease.
+      # (See this file's header checklist.)
+      - name: Build Android APK (debug-signed, sideloadable)
+        run: ./gradlew :app-android:assembleDebug
+
+      - name: Stage APK under a release-friendly name
+        run: |
+          set -euo pipefail
+          ver="${GITHUB_REF_NAME#v}"; [ -n "$ver" ] || ver="0.0.0"
+          apk="$(find app-android/build/outputs/apk -name '*.apk' | head -n1)"
+          if [ -z "$apk" ]; then echo "::error::assembleDebug produced no APK."; exit 1; fi
+          mkdir -p artifacts/android
+          cp "$apk" "artifacts/android/PureTV-${ver}.apk"
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-release
+          path: artifacts/android/*.apk
+          if-no-files-found: error
+
   proxy-image:
     name: Go proxy (Docker image -> GHCR)
     runs-on: ubuntu-latest
@@ -162,20 +203,25 @@ jobs:
 
   draft-release:
     name: Create draft GitHub Release
-    # Only the Windows installer gates the release; Android is non-blocking and
-    # the proxy image publishes itself to GHCR independently.
-    needs: [windows]
+    # The Windows installer and Android APK both gate the release so every draft
+    # carries both downloads; the proxy image publishes to GHCR independently.
+    needs: [windows, android]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Only the Windows installer artifact — downloading all artifacts also
-      # pulls a stray Docker buildx metadata file that intermittently fails.
+      # Named artifacts only — downloading ALL artifacts also pulls a stray Docker
+      # buildx metadata file that intermittently fails.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-release
           path: artifacts/windows-release
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: android-release
+          path: artifacts/android
 
       - name: Resolve version (strip leading v from the tag)
         id: vars
@@ -237,7 +283,9 @@ jobs:
           cat >> notes.md <<'DL'
 
           ---
-          **Download** the installer below and run it. Everything's included, no separate VLC needed. If Windows shows a SmartScreen warning, click **More info, then Run anyway**. Already have PureTV? Just install over it.
+          **Windows:** download the `.exe` below and run it. Everything's included, no separate VLC needed. If Windows shows a SmartScreen warning, click **More info, then Run anyway**. Already have PureTV? Just install over it.
+
+          **Android:** download the `.apk` below, then open it on your phone (you may need to allow installs from your browser/files app). This is a sideloaded build, not from the Play Store.
           DL
           echo "----- release notes -----"; cat notes.md
 
@@ -250,3 +298,4 @@ jobs:
           files: |
             artifacts/windows-release/**/*.exe
             artifacts/windows-release/**/*.exe.sig
+            artifacts/android/**/*.apk

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 # PureTV
 
-A clean, ad-free way to watch live streams on Windows.
+A clean, ad-free way to watch live streams, on Windows and Android.
 
-[![Download PureTV](https://img.shields.io/badge/Download%20PureTV-Windows%20Installer-7C3AED?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/dhawal-ss/puretv/releases/latest)
+[![Download for Windows](https://img.shields.io/badge/Download-Windows%20Installer-7C3AED?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/dhawal-ss/puretv/releases/latest)
+[![Download for Android](https://img.shields.io/badge/Download-Android%20APK-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/dhawal-ss/puretv/releases/latest)
 
-**[Click here to download the latest version](https://github.com/dhawal-ss/puretv/releases/latest)**
+**[Open the latest release](https://github.com/dhawal-ss/puretv/releases/latest).** Under "Assets", pick the `.exe` for Windows or the `.apk` for Android.
 
 </div>
 
@@ -14,13 +15,24 @@ A clean, ad-free way to watch live streams on Windows.
 
 ## Install (about a minute)
 
-1. Click the Download PureTV button above.
+### Windows
+
+1. Click the "Download for Windows" button above.
 2. On the page that opens, under "Assets", click the file that ends in `.exe`.
 3. Open the downloaded file and follow the prompts.
 4. If Windows shows a blue "Windows protected your PC" screen, click "More info", then "Run anyway". This only appears because the app is not code-signed yet, and it is safe to continue.
 5. Open PureTV from your Start menu and sign in.
 
 Everything the app needs is included in the installer, so there is nothing else to set up.
+
+### Android
+
+1. On your phone, click the "Download for Android" button above.
+2. Under "Assets", tap the file that ends in `.apk` to download it.
+3. Open the downloaded file. Android may ask you to allow installs from your browser or Files app the first time, tap Allow, then Install.
+4. Open PureTV and sign in.
+
+The Android app is a sideloaded build (not from the Play Store), so it is normal for Android to warn about installing it. The Android app is newer than the Windows one, so expect a few rough edges.
 
 ## What you get
 

--- a/vlc-help.txt
+++ b/vlc-help.txt
@@ -1,7 +1,0 @@
-﻿VLC version 3.0.23 Vetinari (3.0.23-2-0-g79128878dd)
-Compiled by videolan on runner-sgapdqgx-project-435-concurrent-0 (Dec 23 2025 11:32:53)
-Compiler: gcc version 6.4.0 (GCC)
-This program comes with NO WARRANTY, to the extent permitted by law.
-You may redistribute it under the terms of the GNU General Public License;
-see the file named COPYING for details.
-Written by the VideoLAN team; see the AUTHORS file.


### PR DESCRIPTION
Makes releases and the download page cover **both Windows and Android**, and tidies a scratch file.

## Releases (`release.yml`)
- New **`android`** job builds the phone APK (`:app-android:assembleDebug`), stages it as `PureTV-<version>.apk`, and uploads it as an artifact.
- The draft-release job now **gates on both `windows` and `android`** and attaches the `.apk` next to the `.exe` + `.exe.sig`, so every release carries both downloads.
- Release notes footer now has per-platform install instructions.

## Download buttons (`README.md`)
- Separate **Download for Windows** (`.exe`) and **Download for Android** (`.apk`) badges.
- Per-platform install steps (Android section notes it's a sideloaded, newer build).

## Cleanup
- Remove `vlc-help.txt` (unreferenced `vlc --help` dump). Left `vaft.user.js` in place — it's the TwitchAdSolutions reference the ad-block code cites.

## Follow-up for a production Android build
The APK is **debug-signed** (sideloadable) because no release keystore is wired (`app-android/build.gradle.kts` leaves the release `signingConfig` commented out). For a Play-updatable, release-signed build: add a stable keystore secret (`ANDROID_KEYSTORE_BASE64` + password/alias secrets), wire `signingConfigs` in the android module, and switch the job to `assembleRelease`. The Android auth flow (PkceAuth) also needs `TWITCH_CLIENT_SECRET` injected into this job to be fully functional.

CI (`ci.yml`) already builds `assembleDebug`, so this PR's checks validate the APK path the release job relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)