### PR TITLE
Keep Android on its own release channel; fix README Android link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,47 +128,6 @@ jobs:
           path: app-windows/build/installer/*.exe
           if-no-files-found: error
 
-  android:
-    name: Android phone app (APK)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Cache Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-
-      # No release keystore is wired yet (app-android/build.gradle.kts leaves the
-      # release signingConfig commented out), so we publish the DEBUG-signed APK:
-      # it sideloads like any app from outside the Play Store. For a production,
-      # Play-updatable build, add a stable keystore (ANDROID_KEYSTORE_BASE64 +
-      # ANDROID_KEYSTORE_PASSWORD / KEY_ALIAS / KEY_PASSWORD), wire signingConfigs
-      # in app-android/build.gradle.kts, and switch this to :app-android:assembleRelease.
-      # (See this file's header checklist.)
-      - name: Build Android APK (debug-signed, sideloadable)
-        run: ./gradlew :app-android:assembleDebug
-
-      - name: Stage APK under a release-friendly name
-        run: |
-          set -euo pipefail
-          ver="${GITHUB_REF_NAME#v}"; [ -n "$ver" ] || ver="0.0.0"
-          apk="$(find app-android/build/outputs/apk -name '*.apk' | head -n1)"
-          if [ -z "$apk" ]; then echo "::error::assembleDebug produced no APK."; exit 1; fi
-          mkdir -p artifacts/android
-          cp "$apk" "artifacts/android/PureTV-${ver}.apk"
-
-      - name: Upload Android artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: android-release
-          path: artifacts/android/*.apk
-          if-no-files-found: error
-
   proxy-image:
     name: Go proxy (Docker image -> GHCR)
     runs-on: ubuntu-latest
@@ -203,25 +162,20 @@ jobs:
 
   draft-release:
     name: Create draft GitHub Release
-    # The Windows installer and Android APK both gate the release so every draft
-    # carries both downloads; the proxy image publishes to GHCR independently.
-    needs: [windows, android]
+    # Only the Windows installer gates the release; the Android app is released on
+    # its own `android-v*` channel, and the proxy image publishes to GHCR independently.
+    needs: [windows]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Named artifacts only — downloading ALL artifacts also pulls a stray Docker
-      # buildx metadata file that intermittently fails.
+      # Only the Windows installer artifact — downloading all artifacts also
+      # pulls a stray Docker buildx metadata file that intermittently fails.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-release
           path: artifacts/windows-release
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: android-release
-          path: artifacts/android
 
       - name: Resolve version (strip leading v from the tag)
         id: vars
@@ -283,9 +237,7 @@ jobs:
           cat >> notes.md <<'DL'
 
           ---
-          **Windows:** download the `.exe` below and run it. Everything's included, no separate VLC needed. If Windows shows a SmartScreen warning, click **More info, then Run anyway**. Already have PureTV? Just install over it.
-
-          **Android:** download the `.apk` below, then open it on your phone (you may need to allow installs from your browser/files app). This is a sideloaded build, not from the Play Store.
+          **Download** the installer below and run it. Everything's included, no separate VLC needed. If Windows shows a SmartScreen warning, click **More info, then Run anyway**. Already have PureTV? Just install over it.
           DL
           echo "----- release notes -----"; cat notes.md
 
@@ -298,4 +250,3 @@ jobs:
           files: |
             artifacts/windows-release/**/*.exe
             artifacts/windows-release/**/*.exe.sig
-            artifacts/android/**/*.apk

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 A clean, ad-free way to watch live streams, on Windows and Android.
 
 [![Download for Windows](https://img.shields.io/badge/Download-Windows%20Installer-7C3AED?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/dhawal-ss/puretv/releases/latest)
-[![Download for Android](https://img.shields.io/badge/Download-Android%20APK-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/dhawal-ss/puretv/releases/latest)
+[![Download for Android](https://img.shields.io/badge/Download-Android%20APK-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/dhawal-ss/puretv/releases?q=android&expanded=true)
 
-**[Open the latest release](https://github.com/dhawal-ss/puretv/releases/latest).** Under "Assets", pick the `.exe` for Windows or the `.apk` for Android.
+Windows and Android ship on separate release tracks. The Windows button opens the latest desktop release (grab the `.exe`); the Android button opens the Android releases (grab the newest `.apk`).
 
 </div>
 
@@ -27,7 +27,7 @@ Everything the app needs is included in the installer, so there is nothing else 
 
 ### Android
 
-1. On your phone, click the "Download for Android" button above.
+1. On your phone, click the "Download for Android" button above and open the newest release in the list.
 2. Under "Assets", tap the file that ends in `.apk` to download it.
 3. Open the downloaded file. Android may ask you to allow installs from your browser or Files app the first time, tap Allow, then Install.
 4. Open PureTV and sign in.


### PR DESCRIPTION
Follow-up to the earlier download-buttons change. We're standardizing on a **separate Android release channel** (`android-v*`, owned by the Android effort) rather than bundling the APK into the Windows `v*` releases.

- **release.yml**: removes the Android APK job (the unified `v*` release is Windows-only again; `draft-release` gates on `windows` only).
- **README**: the "Download for Android" button now opens the Android releases (GitHub releases filtered by `?q=android`) instead of `/releases/latest` (which resolves to the Windows desktop release). Version-agnostic, nothing to keep in sync.

Net effect: Windows and Android each have a working download button pointing at their own release track, with no cross-channel ambiguity. The `vlc-help.txt` cleanup from the previous PR stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)