### PR TITLE
Installer force-closes running PureTV before upgrade (safe update transition) — v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ release notes automatically.
 
 ---
 
+## 1.10.1 - 2026-07-01
+
+The first published build of the 1.10 line. It brings the new 7TV / Chatterino-style chat and makes updating reliable.
+
+### New
+- **A much better chat experience.** Live 7TV emote updates (new emotes appear the moment a channel adds them, no restart), real Twitch, subscriber, and moderator badge icons instead of plain text, sub and raid announcements, a highlight when someone mentions you, and a Mentions tab next to chat.
+
+### Fixed
+- **Updates install cleanly now.** Before, installing an update could leave PureTV unable to open (a "cannot open ...cfg" error) until you reinstalled it by hand, because the new files were written while the app was still closing. PureTV now shuts down fully before an update, and the installer force-closes any leftover PureTV first, so updates just work, including the update onto this version from an older one.
+
+Updating from an older version and PureTV will not open afterward? Download the installer above and run it once. That fixes the install, and updates from then on are seamless.
+
 ## 1.10.0 - 2026-06-30
 
 Brings the chat experience closer to 7TV and Chatterino, with live emotes, real badge icons, and proper moderation and event messages.

--- a/app-windows/build.gradle.kts
+++ b/app-windows/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 // ── App version (single source of truth) ─────────────────────────────────────
 // Drives both the MSI `packageVersion` AND the generated AppBuildConfig the
 // in-app updater compares against GitHub Releases — so the two can never drift.
-val appVersion = "1.10.0"
+val appVersion = "1.10.1"
 
 val generateAppBuildConfig by tasks.registering {
     val outDir = layout.buildDirectory.dir("generated/buildconfig/kotlin")

--- a/app-windows/installer/puretv.iss
+++ b/app-windows/installer/puretv.iss
@@ -52,3 +52,26 @@ Name: "{autodesktop}\PureTV"; Filename: "{app}\{#MyAppExe}"
 ; skipifsilent -> do NOT auto-launch during a silent in-app update; the updater
 ;                 handles its own relaunch
 Filename: "{app}\{#MyAppExe}"; Description: "Launch PureTV now"; Flags: nowait postinstall skipifsilent
+
+[Code]
+// PrepareToInstall runs BEFORE the file phase (before the InstallDelete and Files
+// sections), so this is where we make sure no PureTV process is holding app files.
+// Older in-app updaters do not reliably wait for the app to exit: its process can
+// linger on background threads (the local stream proxy / VLC) and keep the app
+// folder locked, so the in-place upgrade wipes that folder but fails to re-copy it,
+// leaving the launcher without its .cfg so the app will not start. Force-closing the
+// process here makes the upgrade succeed even when the OLD updater did not wait,
+// which is what lets users on a pre-fix build update cleanly.
+//
+// taskkill by IMAGE NAME with NO /T on purpose: during an in-app update the script
+// that launched this installer is a descendant of the very app we are killing, so a
+// tree-kill would terminate the installer itself. Best-effort: if PureTV is not
+// running, taskkill simply no-ops.
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  ResultCode: Integer;
+begin
+  Exec('taskkill.exe', '/F /IM "PureTV for Twitch.exe"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Sleep(1500);
+  Result := '';
+end;


### PR DESCRIPTION
Makes the update onto the fixed build safe for **existing users**.

## Why
The updater fix in 1.10.0 protects *future* updates, but a user on an older build applies the update using the **old** updater, which doesn't reliably wait for the app to exit. So the very hop onto the fix could still corrupt the install (the installer wipes `app\` while it's locked; the launcher `.cfg` goes missing; the app won't open).

## Fix
`puretv.iss` gains a `[Code]` `PrepareToInstall` step that force-closes any running `PureTV for Twitch.exe` **before the file phase** (`taskkill /F /IM`, deliberately **no `/T`** so it can't kill the update script that spawned the installer). This guarantees no locks during `InstallDelete`/`Files`, so the upgrade succeeds even when the launching updater didn't wait.

## Also
- Bump to **1.10.1**. The `1.10.1` CHANGELOG section is the first published build of the 1.10 line (carries all the 1.10.0 chat parity) plus this installer robustness fix, with a short recovery note for anyone who still hits a bad hop.
- Verified locally: ISCC parses the new `[Code]` section cleanly (only the expected "app image not built" error remains, which CI satisfies).

Ships as the first **published** 1.10 release, superseding the unpublished 1.10.0 draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)