### PR TITLE
Stream resolution fails loudly instead of handing back a dead URL

### DIFF
--- a/app-tv/src/main/kotlin/com/puretv/twitch/tv/ui/ViewModels.kt
+++ b/app-tv/src/main/kotlin/com/puretv/twitch/tv/ui/ViewModels.kt
@@ -1,5 +1,6 @@
 package com.puretv.twitch.tv.ui
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.puretv.twitch.core.adblock.AdBlockEngine
@@ -342,6 +343,15 @@ data class StreamUiState(
     val adBlockStatus: AdBlockStatus = AdBlockStatus.UNKNOWN,
     val chatMessages: List<ChatMessage> = emptyList(),
     val isLoading: Boolean = true,
+    /**
+     * Why playback could not start, or null while it is fine. Stream resolution
+     * is the ONLY path that produces [playableUrl], so when it fails the screen
+     * has nothing to render: without this the viewer gets a black rectangle with
+     * no audio and no explanation, and chat keeps scrolling beside it (it is a
+     * separate coroutine), which reads as "the app works, the stream is gone".
+     * Mirrors the phone app's `StreamUiState.playbackError`.
+     */
+    val playbackError: String? = null,
 )
 
 class StreamViewModel(
@@ -364,10 +374,7 @@ class StreamViewModel(
             }.getOrNull()
             _state.update { it.copy(channel = channel, streamInfo = liveInfo, isLoading = false) }
 
-            runCatching { streamRepository.resolvePlayableStream(channelLogin) }
-                .onSuccess { playable ->
-                    _state.update { it.copy(playableUrl = playable.masterUrl) }
-                }
+            resolvePlayable()
 
             runCatching { emoteRepository.loadGlobalEmotes() }
             channel?.let { runCatching { emoteRepository.loadChannelEmotes(it.id, it.login) } }
@@ -393,6 +400,37 @@ class StreamViewModel(
         }
     }
 
+    /**
+     * Resolve the signed master-playlist URL the player consumes.
+     *
+     * The failure branch is the point of this function. `runCatching { }` with
+     * only an `onSuccess` swallows every cause — a GQL schema change, a blocked
+     * usher host, an offline channel, a dead network — and leaves [playableUrl]
+     * null, which the screen renders as an indistinguishable black frame. Every
+     * one of those needs a different fix, so the message is surfaced verbatim
+     * and logged under [TAG] for `adb logcat`.
+     */
+    private suspend fun resolvePlayable() {
+        _state.update { it.copy(playbackError = null) }
+        runCatching { streamRepository.resolvePlayableStream(channelLogin) }
+            .onSuccess { playable ->
+                _state.update { it.copy(playableUrl = playable.masterUrl, playbackError = null) }
+            }
+            .onFailure { e ->
+                Log.w(TAG, "Stream resolution failed for $channelLogin", e)
+                val detail = e.message?.takeIf { it.isNotBlank() } ?: e::class.simpleName.orEmpty()
+                _state.update {
+                    it.copy(
+                        playbackError = "Could not load this stream. It may be offline." +
+                            if (detail.isBlank()) "" else "\n\n$detail",
+                    )
+                }
+            }
+    }
+
+    /** Re-run resolution after a failure (OK on the remote). */
+    fun retry() = viewModelScope.launch { resolvePlayable() }
+
     fun sendChatMessage(text: String) = viewModelScope.launch {
         chatClient.sendMessage(channelLogin, text)
     }
@@ -400,6 +438,10 @@ class StreamViewModel(
     override fun onCleared() {
         super.onCleared()
         chatClient.disconnect()
+    }
+
+    private companion object {
+        const val TAG = "StreamViewModel"
     }
 }
 

--- a/app-tv/src/main/kotlin/com/puretv/twitch/tv/ui/screens/TvStreamScreen.kt
+++ b/app-tv/src/main/kotlin/com/puretv/twitch/tv/ui/screens/TvStreamScreen.kt
@@ -5,8 +5,11 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.view.WindowManager
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -31,6 +34,10 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
 import com.puretv.twitch.core.model.StreamQuality
 import com.puretv.twitch.tv.player.TvPlayer
 import com.puretv.twitch.tv.ui.StreamViewModel
@@ -179,8 +186,14 @@ fun TvStreamScreen(
                         if (chatVisible) { chatVisible = false; true } else false
                     }
                     Key.DirectionCenter, Key.Enter, Key.NumPadEnter, Key.MediaPlayPause -> {
-                        tvPlayer.togglePlayPause()
-                        isPlaying = tvPlayer.exoPlayer.isPlaying
+                        // With no playable URL there is nothing to pause, so OK
+                        // becomes the retry affordance the error panel advertises.
+                        if (state.playbackError != null) {
+                            viewModel.retry()
+                        } else {
+                            tvPlayer.togglePlayPause()
+                            isPlaying = tvPlayer.exoPlayer.isPlaying
+                        }
                         true
                     }
                     Key.MediaFastForward -> {
@@ -223,6 +236,30 @@ fun TvStreamScreen(
                 },
                 update = { view -> view.player = tvPlayer.exoPlayer },
             )
+        }
+
+        // Resolution failed: say so instead of leaving a black rectangle. Not
+        // tied to `controlsVisible` — the auto-hide timer must never take the
+        // only explanation of the failure away with it.
+        if (state.playbackError != null) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(48.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
+            ) {
+                Text(
+                    text = state.playbackError!!,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = PureTvTvTheme.colors.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = "Press OK to try again, or BACK to choose another channel.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = PureTvTvTheme.colors.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
         }
 
         TvControlsOverlay(

--- a/core/src/commonMain/kotlin/com/puretv/twitch/core/stream/StreamResolver.kt
+++ b/core/src/commonMain/kotlin/com/puretv/twitch/core/stream/StreamResolver.kt
@@ -8,6 +8,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.encodeURLParameter
+import io.ktor.http.isSuccess
 import kotlin.random.Random
 
 /**
@@ -51,7 +52,24 @@ class StreamResolver(
             "&transcode_mode=cbr_v1"
     }
 
-    /** One-shot: token -> master URL -> raw master playlist text. */
+    /**
+     * One-shot: token -> master URL -> raw master playlist text.
+     *
+     * The usher fetch is VALIDATED before the result is handed back. The shared
+     * Ktor client does not do it for us: `expectSuccess` defaults to false and
+     * `CoreModule`'s `HttpResponseValidator` is deliberately scoped to Helix, so
+     * a usher rejection arrives as an ordinary response whose body is a JSON
+     * error array rather than a playlist (live capture, 2026-09-01:
+     * `403 [{"url":"…","error":"Signature is invalid"}]`).
+     *
+     * Without these checks that body was returned as a SUCCESS — `parseVariants`
+     * simply found no `#EXT-X-STREAM-INF` and produced an empty ladder, while
+     * `masterUrl` pointed at a URL that can never produce media. The caller then
+     * stored it as the playable URL and the player failed on it with nothing to
+     * report, which is a black screen with no audio, no error, and a working
+     * chat beside it. Fail here instead, naming the status, so the cause reaches
+     * the UI and the log.
+     */
     suspend fun resolveMasterPlaylist(
         channelLogin: String,
         oauthToken: String? = null,
@@ -59,7 +77,24 @@ class StreamResolver(
     ): MasterPlaylistResult {
         val token = fetchToken(channelLogin, oauthToken, playerType)
         val url = buildMasterUrl(channelLogin, token)
-        val raw = httpClient.get(url).bodyAsText()
+        val response = httpClient.get(url)
+        val raw = response.bodyAsText()
+
+        if (!response.status.isSuccess()) {
+            throw UsherPlaylistException(
+                "usher refused the master playlist for \"$channelLogin\" (playerType=$playerType): " +
+                    "HTTP ${response.status.value} ${response.status.description}. ${raw.summarize()}",
+            )
+        }
+        // A 200 is not proof of a playlist: usher answers some rejections with a
+        // JSON body and a success status.
+        if (!raw.trimStart().startsWith("#EXTM3U")) {
+            throw UsherPlaylistException(
+                "usher returned HTTP ${response.status.value} for \"$channelLogin\" but the body is not an " +
+                    "HLS playlist. ${raw.summarize()}",
+            )
+        }
+
         return MasterPlaylistResult(masterUrl = url, rawContent = raw, variants = parseVariants(raw))
     }
 
@@ -180,6 +215,20 @@ object HlsMasterParser {
         flush()
         return map
     }
+}
+
+/**
+ * The playback token minted, but usher would not hand back a master playlist —
+ * a rejected/expired signature, a geo- or subscriber-blackout, or a channel that
+ * went offline between the mint and the fetch. Distinct from
+ * [GqlPlaybackTokenException], which means the token itself was never issued.
+ */
+class UsherPlaylistException(message: String) : Exception(message)
+
+/** First line of a response body, bounded, for putting in an error message. */
+private fun String.summarize(limit: Int = 180): String {
+    val firstLine = lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+    return if (firstLine.length <= limit) firstLine else firstLine.take(limit) + "…"
 }
 
 data class MasterPlaylistResult(

--- a/core/src/commonTest/kotlin/com/puretv/twitch/core/adblock/PrerollWindowTest.kt
+++ b/core/src/commonTest/kotlin/com/puretv/twitch/core/adblock/PrerollWindowTest.kt
@@ -1,0 +1,84 @@
+package com.puretv.twitch.core.adblock
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression fixture captured from LIVE Twitch traffic (2026-09-01, playerType
+ * "site", anonymous viewer joining a live channel).
+ *
+ * Every other fixture in this package places content segments AFTER the pod, so
+ * the rewriter always had somewhere to splice back to. Real prerolls do not look
+ * like that: the pod is declared at DURATION=30.235 while the sliding window
+ * holds only ~4 segments, so for the first ~30 seconds of every stream open
+ * EVERY segment in the window is an ad and there is no post-ad content to
+ * return to.
+ */
+class PrerollWindowTest {
+
+    private val rewriter = ManifestRewriter()
+
+    /**
+     * Documents the degenerate case rather than asserting it away: with every
+     * segment in the window belonging to the pod there is no content to splice
+     * back to, so stripping CANNOT produce a playable window. The rewriter is
+     * doing the only correct thing available to it — removing all four ad
+     * segments — and the result is a playlist with no segments at all.
+     *
+     * That is a valid outcome for [ManifestRewriter] and an invalid thing to
+     * hand a player. The decision therefore belongs one layer up, in
+     * `TvAdBlockInterceptor.resolveCleanMedia`, which is the only place that
+     * knows the seamless backup swap was already tried and failed. It currently
+     * returns this content verbatim, which is why an all-ad window reaches
+     * ExoPlayer as an unplayable manifest.
+     */
+    @Test
+    fun allAdWindowStripsEverythingAndLeavesNoSegments() {
+        val result = rewriter.filter(REAL_PREROLL_WINDOW)
+
+        assertTrue(result.containedAds, "a stitched-ad pod must be reported as ads")
+        assertEquals(4, result.adSegmentsRemoved, "all four in-window ad segments should be removed")
+
+        val segmentUris = result.content.lines().filter { it.isNotBlank() && !it.startsWith("#") }
+        assertTrue(
+            segmentUris.isEmpty(),
+            "fixture invariant: this window is entirely ad, so nothing should survive:\n${result.content}",
+        )
+        assertTrue(
+            result.content.startsWith("#EXTM3U"),
+            "even the degenerate result must stay a well-formed playlist:\n${result.content}",
+        )
+    }
+
+    private companion object {
+        val REAL_PREROLL_WINDOW = """
+            #EXTM3U
+            #EXT-X-VERSION:3
+            #EXT-X-TARGETDURATION:5
+            #EXT-X-MEDIA-SEQUENCE:0
+            #EXT-X-TWITCH-ELAPSED-SECS:5926.466
+            #EXT-X-TWITCH-TOTAL-SECS:5934.466
+            #EXT-X-START:TIME-OFFSET=0.000
+            #EXT-X-DATERANGE:ID="playlist-creation-1788289296",CLASS="timestamp",START-DATE="2026-09-01T19:01:36.832Z",END-ON-NEXT=YES,X-SERVER-TIME="1788289296.83"
+            #EXT-X-DATERANGE:ID="playlist-session-1788289296",CLASS="twitch-session",START-DATE="2026-09-01T19:01:36.832Z",END-ON-NEXT=YES,X-TV-TWITCH-SESSIONID="5197382620532188731"
+            #EXT-X-DATERANGE:ID="stitched-ad-1788289291-30235000000",CLASS="twitch-stitched-ad",START-DATE="2026-09-01T19:01:31.355Z",DURATION=30.235,X-TV-TWITCH-AD-CLICK-TRACKING-URL="https://example.invalid/c"
+            #EXT-X-DATERANGE:ID="source-1788289291",CLASS="twitch-stream-source",START-DATE="2026-09-01T19:01:31.355Z",END-ON-NEXT=YES,X-TV-TWITCH-STREAM-SOURCE="Amazon|2474283100494"
+            #EXT-X-DATERANGE:ID="quartile-1788289291-0",CLASS="twitch-ad-quartile",START-DATE="2026-09-01T19:01:31.355Z",DURATION=2.000,X-TV-TWITCH-AD-QUARTILE="0"
+            #EXT-X-DISCONTINUITY
+            #EXT-X-PROGRAM-DATE-TIME:2026-09-01T19:01:31.355Z
+            #EXTINF:2.000,Amazon|2474283100494
+            https://cdn.invalid/v1/segment/ad-0
+            #EXT-X-PROGRAM-DATE-TIME:2026-09-01T19:01:33.355Z
+            #EXTINF:2.000,Amazon|2474283100494
+            https://cdn.invalid/v1/segment/ad-1
+            #EXT-X-PROGRAM-DATE-TIME:2026-09-01T19:01:35.355Z
+            #EXTINF:2.000,Amazon|2474283100494
+            https://cdn.invalid/v1/segment/ad-2
+            #EXT-X-DATERANGE:ID="quartile-1788289297-1",CLASS="twitch-ad-quartile",START-DATE="2026-09-01T19:01:37.355Z",DURATION=2.000,X-TV-TWITCH-AD-QUARTILE="1"
+            #EXT-X-PROGRAM-DATE-TIME:2026-09-01T19:01:37.355Z
+            #EXTINF:2.000,Amazon|2474283100494
+            https://cdn.invalid/v1/segment/ad-3
+        """.trimIndent()
+    }
+}

--- a/core/src/commonTest/kotlin/com/puretv/twitch/core/stream/UsherResponseValidationTest.kt
+++ b/core/src/commonTest/kotlin/com/puretv/twitch/core/stream/UsherResponseValidationTest.kt
@@ -1,0 +1,84 @@
+package com.puretv.twitch.core.stream
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+
+/**
+ * The shared Ktor client deliberately does NOT validate usher responses
+ * (`HttpResponseValidator` in `CoreModule` is scoped to Helix, and Ktor's
+ * `expectSuccess` defaults to false), so a usher rejection arrives here as an
+ * ordinary response carrying a JSON error body.
+ *
+ * Captured from live traffic on 2026-09-01: a usher master fetch with a bad
+ * signature answers `403` with a JSON array body, NOT a playlist. Without a
+ * check, [StreamResolver.resolveMasterPlaylist] returns that as a SUCCESS —
+ * `variants` parses to empty and `masterUrl` points at a URL that will never
+ * produce media. The caller stores it as `playableUrl`, the player fails on it,
+ * and the viewer gets a black screen with no audio and no error, while chat
+ * (a separate connection) keeps working. Resolution must fail loudly instead.
+ */
+class UsherResponseValidationTest {
+
+    private val tokenJson =
+        """{"data":{"streamPlaybackAccessToken":{"value":"{}","signature":"sig"}}}"""
+
+    /** Live-captured shape of a usher rejection body. */
+    private val usher403Body =
+        """[{"url":"/api/channel/hls/teamliquid.m3u8","error":"Signature is invalid","error_code":"invalid_signature"}]"""
+
+    private val validMaster = """
+        #EXTM3U
+        #EXT-X-STREAM-INF:BANDWIDTH=8029169,RESOLUTION=1920x1080,CODECS="avc1.64002A,mp4a.40.2",VIDEO="chunked",FRAME-RATE=60.000
+        https://video-edge.example/chunked.m3u8
+    """.trimIndent()
+
+    private fun resolver(usherStatus: HttpStatusCode, usherBody: String): StreamResolver {
+        val client = HttpClient(MockEngine { request ->
+            if (request.url.host.contains("gql")) {
+                respond(tokenJson, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+            } else {
+                respond(usherBody, usherStatus, headersOf(HttpHeaders.ContentType, "application/json"))
+            }
+        })
+        return StreamResolver(client, TwitchGqlClient(client))
+    }
+
+    @Test
+    fun usherRejectionFailsInsteadOfReturningADeadUrl() = runTest {
+        val failure = assertFails {
+            resolver(HttpStatusCode.Forbidden, usher403Body).resolveMasterPlaylist("teamliquid")
+        }
+        val message = failure.message.orEmpty()
+        assertTrue(
+            "403" in message,
+            "the failure must name usher's status so the viewer/log can tell a rejection from an outage: $message",
+        )
+    }
+
+    @Test
+    fun usherBodyThatIsNotAPlaylistFails() = runTest {
+        val failure = assertFails {
+            resolver(HttpStatusCode.OK, usher403Body).resolveMasterPlaylist("teamliquid")
+        }
+        assertTrue(
+            failure.message.orEmpty().isNotBlank(),
+            "a 200 carrying a non-playlist body is still not playable and must fail",
+        )
+    }
+
+    @Test
+    fun healthyMasterStillResolves() = runTest {
+        val result = resolver(HttpStatusCode.OK, validMaster).resolveMasterPlaylist("teamliquid")
+        assertEquals(1, result.variants.size, "a real master must still parse into its variant ladder")
+        assertTrue(result.masterUrl.startsWith("https://usher.ttvnw.net/"), result.masterUrl)
+    }
+}


### PR DESCRIPTION
A blank TV player with working chat had no way to explain itself. Two gaps on the same path, either of which turns any failure into a black rectangle with no audio and no message.

resolveMasterPlaylist never checked the usher response. Ktor's expectSuccess defaults to false and CoreModule's HttpResponseValidator is deliberately scoped to Helix, so a usher rejection arrives as an ordinary response whose body is a JSON error array rather than a playlist. Captured from live traffic: a bad signature answers 403 with [{"url":"...","error":"Signature is invalid"}]. That body was returned as a SUCCESS -- parseVariants simply found no #EXT-X-STREAM-INF and produced an empty ladder, while masterUrl pointed at a URL that can never produce media. The caller stored it as the playable URL and the player failed on it with nothing to report. It now throws UsherPlaylistException naming the status, and a 200 whose body is not a playlist is rejected too, since usher answers some rejections that way.

The TV app then swallowed whatever came back. StreamViewModel used runCatching { }.onSuccess { } with no onFailure, so a GQL schema change, a blocked usher host, an offline channel and a dead network were all discarded identically, leaving playableUrl null. Chat kept scrolling beside it because it is a separate coroutine, which reads as "the app works, the stream is gone". The phone app has carried playbackError and retry() since its first release; the TV app never got them. Ported, with the message on screen and OK bound to retry while resolution has failed.

All four callers of resolveMasterPlaylist already wrap it, so throwing is contained: BackupStreamResolver simply moves to the next player type, which makes the ad-block backup swap more accurate rather than less.

PrerollWindowTest is unrelated to the above and fixes nothing. It records, from live traffic, that a real preroll declares DURATION=30.2 while the sliding window holds only ad segments, so ManifestRewriter correctly strips it to zero segments -- a valid rewriter result and an invalid thing to hand a player. Every existing fixture places content after the pod, so nothing covered this. The fix belongs in resolveCleanMedia, the only layer that knows the backup swap was already tried, and is left for its own change.