### PR TITLE
Ask for install consent before anything is downloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ release notes automatically.
 
 ---
 
+## Android 1.1.3 and Android TV 1.2.4 - 2026-09-01
+
+Updating itself is the fix, on both the phone and TV apps. Windows is unchanged.
+
+### Fixed
+- **Updating no longer strands the app.** The app used to start downloading an
+  update and only then ask Android for permission to install it, so the trip to
+  the system permission screen happened part-way through, with a downloaded file
+  and a half-open install already in progress. Some televisions did not come back
+  from that, leaving an app that would not open at all. Permission is now asked
+  for first, before anything is downloaded, so there is nothing in progress to
+  lose.
+- **Allowing it is only asked for once.** Coming back from the permission screen
+  used to land you right back on the screen asking for the permission you had
+  just given. The app now sees that it has been granted and gets on with the
+  update, at most asking you to press install one more time.
+- **The permission screen is found on more devices.** Some televisions list it
+  per-app and some only have a general one, and only the first was looked for.
+  Both are now, and on sets that have neither the app prints the exact menu path
+  instead of offering a button that does nothing.
+- **Unfinished updates are cleared away.** Every interrupted attempt used to
+  leave something behind, and enough of them would eventually stop new updates
+  from starting at all.
+
 ## Android TV 1.2.3 - 2026-09-01
 
 A black screen now explains itself. Android and Windows are unchanged.

--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         // versionCode is the monotonic value the in-app updater compares against
         // the published android-version.json (see docs/android-version.json).
         // Bump it on every Android release so the updater offers the new APK.
-        versionCode = 6
-        versionName = "1.1.2"
+        versionCode = 7
+        versionName = "1.1.3"
         ndk { abiFilters += listOf("armeabi-v7a", "arm64-v8a") } // skip x86 to cut APK size
     }
 

--- a/app-android/src/main/AndroidManifest.xml
+++ b/app-android/src/main/AndroidManifest.xml
@@ -12,6 +12,17 @@
          consent the first time; this permission is what lets us ask. -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
+    <!-- Package visibility (API 30+): the updater resolves the "install unknown
+         apps" consent screen before offering a button for it, and resolution is
+         filtered like any other cross-package lookup. Without this the match can
+         come back empty on some builds and a device that HAS the screen gets the
+         written directions instead. -->
+    <queries>
+        <intent>
+            <action android:name="android.settings.MANAGE_UNKNOWN_APP_SOURCES" />
+        </intent>
+    </queries>
+
     <application
         android:name=".PureTvApp"
         android:allowBackup="false"

--- a/app-android/src/main/kotlin/com/puretv/twitch/android/MainActivity.kt
+++ b/app-android/src/main/kotlin/com/puretv/twitch/android/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.core.view.WindowCompat
 import androidx.media3.common.util.UnstableApi
 import androidx.navigation.compose.rememberNavController
 import com.puretv.twitch.android.player.TwitchPlayer
+import com.puretv.twitch.android.update.AndroidUpdateManager
 import com.puretv.twitch.android.ui.RootScreen
 import com.puretv.twitch.android.ui.Routes
 import com.puretv.twitch.android.data.AppSettingsStore
@@ -156,6 +157,18 @@ class MainActivity : ComponentActivity() {
      * recents) while watching a stream keeps playback visible in a floating
      * window. The 16:9 aspect ratio matches Twitch's source video shape.
      */
+    /**
+     * Picks the update back up after the viewer has been to system Settings to
+     * grant "install unknown apps". Nothing was downloaded before they left, by
+     * design, so this only re-reads consent and starts the deferred install.
+     * Best-effort, and never worth taking the Activity down for.
+     */
+    override fun onResume() {
+        super.onResume()
+        runCatching { getKoin().get<AndroidUpdateManager>().refreshInstallConsent() }
+            .onFailure { Log.w(TAG, "Could not re-check install consent", it) }
+    }
+
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
         // Only float a PiP window when a stream is actually playing. Entering PiP

--- a/app-android/src/main/kotlin/com/puretv/twitch/android/MainActivity.kt
+++ b/app-android/src/main/kotlin/com/puretv/twitch/android/MainActivity.kt
@@ -153,11 +153,6 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Section 6.5 — entering PiP when the user navigates away (home button,
-     * recents) while watching a stream keeps playback visible in a floating
-     * window. The 16:9 aspect ratio matches Twitch's source video shape.
-     */
-    /**
      * Picks the update back up after the viewer has been to system Settings to
      * grant "install unknown apps". Nothing was downloaded before they left, by
      * design, so this only re-reads consent and starts the deferred install.
@@ -169,6 +164,11 @@ class MainActivity : ComponentActivity() {
             .onFailure { Log.w(TAG, "Could not re-check install consent", it) }
     }
 
+    /**
+     * Section 6.5 — entering PiP when the user navigates away (home button,
+     * recents) while watching a stream keeps playback visible in a floating
+     * window. The 16:9 aspect ratio matches Twitch's source video shape.
+     */
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
         // Only float a PiP window when a stream is actually playing. Entering PiP

--- a/app-android/src/main/kotlin/com/puretv/twitch/android/ui/screens/HomeScreen.kt
+++ b/app-android/src/main/kotlin/com/puretv/twitch/android/ui/screens/HomeScreen.kt
@@ -150,8 +150,15 @@ fun HomeScreen(
                 contentPadding = PaddingValues(16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                (updateState as? AndroidUpdateState.Available)?.let { available ->
-                    item { UpdateAvailableBanner(versionName = available.info.versionName, onClick = onOpenSettings) }
+                // NeedsInstallConsent counts too: that is the state where the
+                // update is furthest along and most easily forgotten, since it
+                // is waiting on the viewer rather than on us.
+                when (val u = updateState) {
+                    is AndroidUpdateState.Available -> u.info.versionName
+                    is AndroidUpdateState.NeedsInstallConsent -> u.info.versionName
+                    else -> null
+                }?.let { versionName ->
+                    item { UpdateAvailableBanner(versionName = versionName, onClick = onOpenSettings) }
                 }
 
                 val hero = featuredStream(state.followedLive, state.topStreams)

--- a/app-android/src/main/kotlin/com/puretv/twitch/android/ui/screens/SettingsScreen.kt
+++ b/app-android/src/main/kotlin/com/puretv/twitch/android/ui/screens/SettingsScreen.kt
@@ -145,6 +145,7 @@ fun SettingsScreen(onBack: () -> Unit) {
             state = updateState,
             onCheck = { updateManager.checkForUpdates(force = true) },
             onInstall = { info -> updateManager.downloadAndInstall(info) },
+            onGrantConsent = { updateManager.openInstallSettings() },
         )
         Spacer(Modifier.height(24.dp))
     }
@@ -433,6 +434,7 @@ private fun AboutPanel(
     state: AndroidUpdateState,
     onCheck: () -> Unit,
     onInstall: (AndroidUpdateInfo) -> Unit,
+    onGrantConsent: () -> Unit,
 ) {
     val c = PureTvTheme.colors
     ExpressivePanel {
@@ -498,6 +500,39 @@ private fun AboutPanel(
                     Text(state.message, style = MaterialTheme.typography.bodyMedium, color = c.error)
                     Spacer(Modifier.height(12.dp))
                     ExpressiveButton(text = "Try again", onClick = onCheck, style = ExpressiveButtonStyle.Outlined)
+                }
+                is AndroidUpdateState.NeedsInstallConsent -> {
+                    Spacer(Modifier.height(20.dp))
+                    ExpressiveDivider()
+                    Spacer(Modifier.height(20.dp))
+                    Text(
+                        "Update ${state.info.versionName} is ready to install.",
+                        style = PureTvType.data,
+                        color = c.primary,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    if (state.settingsResolvable) {
+                        // Nothing is downloaded yet, so leaving for Settings costs
+                        // nothing even if this app is stopped on the way back.
+                        Text(
+                            "Android needs your permission before PureTV can install it. " +
+                                "Choose Allow on the next screen, then come back and the update will continue.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = c.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        ExpressiveButton(text = "Allow and continue", onClick = onGrantConsent)
+                    } else {
+                        Text(
+                            "This device has no in-app permission screen. Open Settings, find Apps, " +
+                                "then Special app access, then Install unknown apps, and turn it on for " +
+                                "PureTV. Then come back and press Check for updates.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = c.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        ExpressiveButton(text = "Check for updates", onClick = onCheck, style = ExpressiveButtonStyle.Outlined)
+                    }
                 }
                 AndroidUpdateState.Idle -> {
                     Spacer(Modifier.height(20.dp))

--- a/app-android/src/main/kotlin/com/puretv/twitch/android/update/AndroidUpdateManager.kt
+++ b/app-android/src/main/kotlin/com/puretv/twitch/android/update/AndroidUpdateManager.kt
@@ -161,9 +161,13 @@ class AndroidUpdateManager(private val context: Context) {
     }
 
     /**
-     * Re-evaluates consent and resumes on its own if it has since been granted.
-     * Call from the Activity's onResume: the viewer who grants consent and comes
-     * back must not land on the screen asking for what they just gave.
+     * Re-evaluates consent and resumes if it has since been granted. Call from
+     * the Activity's onResume: the viewer who grants consent and comes back must
+     * not land on the screen asking for what they just gave.
+     *
+     * Auto-continues only when the process survived the detour. If it did not,
+     * start-up re-surfaces the update and the next press passes the consent gate
+     * rather than dead-ending at the installer.
      */
     fun refreshInstallConsent() {
         val pending = _state.value as? AndroidUpdateState.NeedsInstallConsent ?: return
@@ -177,24 +181,43 @@ class AndroidUpdateManager(private val context: Context) {
         runCatching { context.packageManager.canRequestPackageInstalls() }.getOrDefault(false)
 
     /** The per-app "install unknown apps" screen. Absent on some OEM builds. */
-    private fun installSettingsIntent(): Intent =
+    private fun packageScopedInstallSettings(): Intent =
         Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES, Uri.parse("package:" + context.packageName))
             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    private fun bareInstallSettings(): Intent =
+        Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    /**
+     * The first of the two forms this device actually resolves, or null when it
+     * publishes neither.
+     *
+     * Both are probed because intent resolution only matches a filter that
+     * declares a `<data>` scheme when the Intent carries a URI. A build whose
+     * Settings activity declares the action without `scheme="package"` resolves
+     * the bare form and NOT the package-scoped one, which would otherwise be
+     * read as "this device has no consent screen" and downgrade a working set to
+     * the written directions. Package-scoped is tried first because it lands
+     * directly on this app's row instead of a list to hunt through.
+     */
+    private fun resolvableInstallSettings(): Intent? = runCatching {
+        listOf(packageScopedInstallSettings(), bareInstallSettings())
+            .firstOrNull { context.packageManager.queryIntentActivities(it, 0).isNotEmpty() }
+    }.getOrNull()
 
     /**
      * Resolved rather than attempted, so the UI can print directions where the
      * screen does not exist instead of offering a button that does nothing.
      * queryIntentActivities stays accurate under API 30+ package visibility.
      */
-    private fun canOpenInstallSettings(): Boolean = runCatching {
-        context.packageManager.queryIntentActivities(installSettingsIntent(), 0).isNotEmpty()
-    }.getOrDefault(false)
+    private fun canOpenInstallSettings(): Boolean = resolvableInstallSettings() != null
 
     /** Sends the viewer to the consent screen; false when there was nowhere to go. */
-    fun openInstallSettings(): Boolean = runCatching {
-        context.startActivity(installSettingsIntent())
-        true
-    }.getOrDefault(false)
+    fun openInstallSettings(): Boolean {
+        val intent = resolvableInstallSettings() ?: return false
+        return runCatching { context.startActivity(intent); true }.getOrDefault(false)
+    }
 
     /**
      * Drops every install session this app owns. Deliberately not filtered by

--- a/app-android/src/main/kotlin/com/puretv/twitch/android/update/AndroidUpdateManager.kt
+++ b/app-android/src/main/kotlin/com/puretv/twitch/android/update/AndroidUpdateManager.kt
@@ -137,28 +137,36 @@ class AndroidUpdateManager(private val context: Context) {
      * viewer leaves while this app holds nothing at all.
      */
     fun downloadAndInstall(info: AndroidUpdateInfo) {
-        when (_state.value) {
-            is AndroidUpdateState.Downloading, AndroidUpdateState.Installing -> return
-            else -> Unit
-        }
-        // Anti-downgrade before consent: someone already on the newest build must
-        // never be sent to Settings for an install that would then be refused.
-        when (updateGate(info.versionCode, currentVersionCode, hasInstallConsent())) {
-            UpdateGate.ALREADY_CURRENT -> {
-                _state.value = AndroidUpdateState.UpToDate
-                return
-            }
-            UpdateGate.NEEDS_INSTALL_CONSENT -> {
-                _state.value = AndroidUpdateState.NeedsInstallConsent(info, canOpenInstallSettings())
-                return
-            }
-            UpdateGate.READY_TO_INSTALL -> Unit
-        }
-        // Claimed before the coroutine starts, so a second caller cannot slip
-        // between the gate above and the first state write inside it.
+        // Claimed before anything else, so a second caller cannot slip between
+        // the gate and the first state write.
         if (!installInFlight.compareAndSet(false, true)) return
         scope.launch {
             try {
+                when (_state.value) {
+                    is AndroidUpdateState.Downloading, AndroidUpdateState.Installing -> return@launch
+                    else -> Unit
+                }
+                // The gate itself runs here rather than on the caller's thread.
+                // Every branch of it reads the package manager (getPackageInfo,
+                // canRequestPackageInstalls, and up to two queryIntentActivities),
+                // and the caller is a button press on the main thread. Those are
+                // binder round-trips and this is the primary user-initiated path,
+                // which is exactly where they must not block the frame.
+                //
+                // Anti-downgrade before consent: someone already on the newest
+                // build must never be sent to Settings for an install that would
+                // then be refused.
+                when (updateGate(info.versionCode, currentVersionCode, hasInstallConsent())) {
+                    UpdateGate.ALREADY_CURRENT -> {
+                        _state.value = AndroidUpdateState.UpToDate
+                        return@launch
+                    }
+                    UpdateGate.NEEDS_INSTALL_CONSENT -> {
+                        _state.value = AndroidUpdateState.NeedsInstallConsent(info, canOpenInstallSettings())
+                        return@launch
+                    }
+                    UpdateGate.READY_TO_INSTALL -> Unit
+                }
                 runCatching {
                     _state.value = AndroidUpdateState.Downloading(0f)
                     val apk = downloadApk(info)
@@ -195,11 +203,27 @@ class AndroidUpdateManager(private val context: Context) {
      * rather than dead-ending at the installer.
      */
     fun refreshInstallConsent() {
-        val pending = _state.value as? AndroidUpdateState.NeedsInstallConsent ?: return
-        // canRequestPackageInstalls is a binder call and this runs on onResume,
-        // so it does not belong on the main thread.
-        scope.launch { if (hasInstallConsent()) downloadAndInstall(pending.info) }
+        // All of this touches the package manager, and onResume is the main
+        // thread, so none of it is done here.
+        scope.launch {
+            // A confirm dialog whose result never reached the receiver leaves
+            // Installing set for the rest of the process, and every other entry
+            // point declines to leave that state, so the Settings screen would
+            // show a spinner forever. Being foregrounded again with none of our
+            // own sessions still open is good evidence it is over, however it
+            // ended.
+            if (_state.value == AndroidUpdateState.Installing && !hasOpenSession()) {
+                _state.value = AndroidUpdateState.Idle
+            }
+            val pending = _state.value as? AndroidUpdateState.NeedsInstallConsent ?: return@launch
+            if (hasInstallConsent()) downloadAndInstall(pending.info)
+        }
     }
+
+    /** Whether any install session of ours is still open. */
+    private fun hasOpenSession(): Boolean = runCatching {
+        context.packageManager.packageInstaller.mySessions.isNotEmpty()
+    }.getOrDefault(false)
 
     /** Whether the OS will let us commit an install session for our own package. */
     private fun hasInstallConsent(): Boolean =
@@ -234,14 +258,30 @@ class AndroidUpdateManager(private val context: Context) {
     /**
      * Resolved rather than attempted, so the UI can print directions where the
      * screen does not exist instead of offering a button that does nothing.
-     * queryIntentActivities stays accurate under API 30+ package visibility.
+     * Package-visibility filtering applies to this the same way it applies to
+     * resolveActivity, so the manifest declares a <queries> entry for the action;
+     * without it an OEM build could filter the match and downgrade a capable
+     * device to the directions text.
      */
     private fun canOpenInstallSettings(): Boolean = resolvableInstallSettings() != null
 
-    /** Sends the viewer to the consent screen; false when there was nowhere to go. */
-    fun openInstallSettings(): Boolean {
-        val intent = resolvableInstallSettings() ?: return false
-        return runCatching { context.startActivity(intent); true }.getOrDefault(false)
+    /**
+     * Sends the viewer to the consent screen.
+     *
+     * When there is nowhere to send them, or the launch is refused, the state
+     * drops to the written-directions variant rather than leaving a button that
+     * silently does nothing. settingsResolvable was decided at gate time and the
+     * launch can still fail after it, so this is the only place to catch that.
+     */
+    fun openInstallSettings() {
+        scope.launch {
+            val intent = resolvableInstallSettings()
+            val launched = intent != null &&
+                runCatching { context.startActivity(intent); true }.getOrDefault(false)
+            if (launched) return@launch
+            val pending = _state.value as? AndroidUpdateState.NeedsInstallConsent ?: return@launch
+            _state.value = pending.copy(settingsResolvable = false)
+        }
     }
 
     /**
@@ -254,6 +294,15 @@ class AndroidUpdateManager(private val context: Context) {
         runCatching {
             val installer = context.packageManager.packageInstaller
             installer.mySessions.forEach { session ->
+                // A committed session is waiting on the system confirm dialog,
+                // which outlives this process. Abandoning that would cancel an
+                // install the viewer is being asked about right now, so only
+                // sessions still open for writing are swept. isCommitted arrived
+                // in API 29; below it the distinction is not observable, and
+                // there the leak is the worse of the two problems.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && session.isCommitted) {
+                    return@forEach
+                }
                 runCatching { installer.abandonSession(session.sessionId) }
                     .onFailure { Log.w(TAG, "Could not abandon stale install session " + session.sessionId, it) }
             }

--- a/app-android/src/main/kotlin/com/puretv/twitch/android/update/AndroidUpdateManager.kt
+++ b/app-android/src/main/kotlin/com/puretv/twitch/android/update/AndroidUpdateManager.kt
@@ -6,6 +6,10 @@ import android.content.Intent
 import android.content.pm.PackageInstaller
 import android.net.Uri
 import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import com.puretv.twitch.core.update.UpdateGate
+import com.puretv.twitch.core.update.updateGate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -60,6 +64,18 @@ class AndroidUpdateManager(private val context: Context) {
     private fun packageInfo() = context.packageManager.getPackageInfo(context.packageName, 0)
 
     init {
+        // Anything still open belongs to an update that did not finish: a
+        // successful one replaces this process, so a surviving session by
+        // definition did not succeed. They are never resumed, and the OS caps how
+        // many an installer may hold, so sweeping at start-up is what keeps a
+        // string of interrupted updates from eventually making createSession fail.
+        //
+        // On `scope` (IO) rather than inline: this singleton can first be resolved
+        // from the Activity's onResume, on the main thread, and mySessions and
+        // abandonSession are binder calls. Construction stays cheap wherever it
+        // happens, which is the same rule the rest of start-up follows.
+        scope.launch { abandonOrphanedSessions() }
+
         // Surface a failed system-side install (the user cancelled the confirm
         // dialog, signature mismatch, etc.) back into our UI. Success replaces the
         // running app, so there's nothing to show for it.
@@ -93,17 +109,35 @@ class AndroidUpdateManager(private val context: Context) {
         }
     }
 
-    /** Downloads [info]'s APK and launches the system installer. */
+    /**
+     * Downloads [info]'s APK and launches the system installer, but only once
+     * the OS has agreed to let us install at all.
+     *
+     * The consent check happens HERE, before the download and before any
+     * session exists. A sideloaded app has no "install unknown apps" consent
+     * until the viewer grants it, and granting it means leaving for system
+     * Settings. Committing a session first meant that detour started with an APK
+     * on disk and a live installer session, and the app did not reliably come
+     * back from it (reported on TV, same code shape here). Asking first means the
+     * viewer leaves while this app holds nothing at all.
+     */
     fun downloadAndInstall(info: AndroidUpdateInfo) {
         when (_state.value) {
             is AndroidUpdateState.Downloading, AndroidUpdateState.Installing -> return
             else -> Unit
         }
-        // Anti-downgrade: never install something that isn't strictly newer, even
-        // if the manifest was edited to point at an older APK.
-        if (info.versionCode <= currentVersionCode) {
-            _state.value = AndroidUpdateState.UpToDate
-            return
+        // Anti-downgrade before consent: someone already on the newest build must
+        // never be sent to Settings for an install that would then be refused.
+        when (updateGate(info.versionCode, currentVersionCode, hasInstallConsent())) {
+            UpdateGate.ALREADY_CURRENT -> {
+                _state.value = AndroidUpdateState.UpToDate
+                return
+            }
+            UpdateGate.NEEDS_INSTALL_CONSENT -> {
+                _state.value = AndroidUpdateState.NeedsInstallConsent(info, canOpenInstallSettings())
+                return
+            }
+            UpdateGate.READY_TO_INSTALL -> Unit
         }
         scope.launch {
             runCatching {
@@ -120,9 +154,62 @@ class AndroidUpdateManager(private val context: Context) {
     /** Reset a terminal error / "up to date" back to idle (e.g. dismiss a banner). */
     fun dismiss() {
         when (_state.value) {
-            is AndroidUpdateState.Error, AndroidUpdateState.UpToDate -> _state.value = AndroidUpdateState.Idle
+            is AndroidUpdateState.Error, AndroidUpdateState.UpToDate, is AndroidUpdateState.NeedsInstallConsent ->
+                _state.value = AndroidUpdateState.Idle
             else -> Unit
         }
+    }
+
+    /**
+     * Re-evaluates consent and resumes on its own if it has since been granted.
+     * Call from the Activity's onResume: the viewer who grants consent and comes
+     * back must not land on the screen asking for what they just gave.
+     */
+    fun refreshInstallConsent() {
+        val pending = _state.value as? AndroidUpdateState.NeedsInstallConsent ?: return
+        // canRequestPackageInstalls is a binder call and this runs on onResume,
+        // so it does not belong on the main thread.
+        scope.launch { if (hasInstallConsent()) downloadAndInstall(pending.info) }
+    }
+
+    /** Whether the OS will let us commit an install session for our own package. */
+    private fun hasInstallConsent(): Boolean =
+        runCatching { context.packageManager.canRequestPackageInstalls() }.getOrDefault(false)
+
+    /** The per-app "install unknown apps" screen. Absent on some OEM builds. */
+    private fun installSettingsIntent(): Intent =
+        Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES, Uri.parse("package:" + context.packageName))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    /**
+     * Resolved rather than attempted, so the UI can print directions where the
+     * screen does not exist instead of offering a button that does nothing.
+     * queryIntentActivities stays accurate under API 30+ package visibility.
+     */
+    private fun canOpenInstallSettings(): Boolean = runCatching {
+        context.packageManager.queryIntentActivities(installSettingsIntent(), 0).isNotEmpty()
+    }.getOrDefault(false)
+
+    /** Sends the viewer to the consent screen; false when there was nowhere to go. */
+    fun openInstallSettings(): Boolean = runCatching {
+        context.startActivity(installSettingsIntent())
+        true
+    }.getOrDefault(false)
+
+    /**
+     * Drops every install session this app owns. Deliberately not filtered by
+     * `appPackageName`: a session abandoned before it was fully configured
+     * reports that field as null, and those are precisely the orphans worth
+     * clearing. `mySessions` is already scoped to this installer.
+     */
+    private fun abandonOrphanedSessions() {
+        runCatching {
+            val installer = context.packageManager.packageInstaller
+            installer.mySessions.forEach { session ->
+                runCatching { installer.abandonSession(session.sessionId) }
+                    .onFailure { Log.w(TAG, "Could not abandon stale install session " + session.sessionId, it) }
+            }
+        }.onFailure { Log.w(TAG, "Could not enumerate install sessions", it) }
     }
 
     private fun fetchLatest(): AndroidUpdateInfo? {
@@ -212,6 +299,7 @@ class AndroidUpdateManager(private val context: Context) {
     }
 
     private companion object {
+        const val TAG = "AndroidUpdateManager"
         const val VERSION_MANIFEST_URL =
             "https://github.com/dhawal-ss/puretv/releases/download/android-latest/android-version.json"
     }
@@ -234,6 +322,18 @@ sealed interface AndroidUpdateState {
     data class Downloading(val progress: Float) : AndroidUpdateState
     data object Installing : AndroidUpdateState
     data class Error(val message: String) : AndroidUpdateState
+
+    /**
+     * A newer build is ready but the OS will not install it until the viewer
+     * grants "install unknown apps". Reached before anything is downloaded, so
+     * leaving for Settings from here costs nothing if the process does not
+     * survive the trip. [settingsResolvable] is false where the per-app consent
+     * screen does not exist and the UI must print directions instead.
+     */
+    data class NeedsInstallConsent(
+        val info: AndroidUpdateInfo,
+        val settingsResolvable: Boolean,
+    ) : AndroidUpdateState
 }
 
 /**

--- a/app-android/src/main/kotlin/com/puretv/twitch/android/update/AndroidUpdateManager.kt
+++ b/app-android/src/main/kotlin/com/puretv/twitch/android/update/AndroidUpdateManager.kt
@@ -23,6 +23,7 @@ import okhttp3.Request
 import org.json.JSONObject
 import java.io.File
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * SECTION 09, in-app updater for the sideloaded phone/tablet APK, over GitHub
@@ -47,6 +48,20 @@ class AndroidUpdateManager(private val context: Context) {
         .connectTimeout(15, TimeUnit.SECONDS)
         .readTimeout(60, TimeUnit.SECONDS)
         .build()
+
+    /**
+     * Claims the install path exactly once.
+     *
+     * The state check below is read-then-write and therefore racy, and this
+     * change made the race reachable: [refreshInstallConsent] fires from
+     * onResume, which can run more than once in quick succession, and a TV
+     * remote's OK button is easy to press twice. Two callers could both read
+     * a non-installing state before either wrote [AndroidUpdateState.Downloading],
+     * and the loser used to go on to a second download and a second committed
+     * session. Sessions that overlap like that are precisely what this change
+     * exists to stop leaving behind.
+     */
+    private val installInFlight = AtomicBoolean(false)
 
     private val _state = MutableStateFlow<AndroidUpdateState>(AndroidUpdateState.Idle)
     val state: StateFlow<AndroidUpdateState> = _state.asStateFlow()
@@ -139,14 +154,24 @@ class AndroidUpdateManager(private val context: Context) {
             }
             UpdateGate.READY_TO_INSTALL -> Unit
         }
+        // Claimed before the coroutine starts, so a second caller cannot slip
+        // between the gate above and the first state write inside it.
+        if (!installInFlight.compareAndSet(false, true)) return
         scope.launch {
-            runCatching {
-                _state.value = AndroidUpdateState.Downloading(0f)
-                val apk = downloadApk(info)
-                _state.value = AndroidUpdateState.Installing
-                installApk(apk)
-            }.onFailure { e ->
-                _state.value = AndroidUpdateState.Error(e.message ?: "Update failed.")
+            try {
+                runCatching {
+                    _state.value = AndroidUpdateState.Downloading(0f)
+                    val apk = downloadApk(info)
+                    _state.value = AndroidUpdateState.Installing
+                    installApk(apk)
+                }.onFailure { e ->
+                    _state.value = AndroidUpdateState.Error(e.message ?: "Update failed.")
+                }
+            } finally {
+                // By here the state is Installing (the system confirm dialog is
+                // up, and the ordinary guard blocks re-entry) or Error (a retry
+                // is exactly what should be allowed), so releasing is safe.
+                installInFlight.set(false)
             }
         }
     }

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         // versionCode is the monotonic value the in-app updater compares against
         // the published tv-version.json (see docs/tv-version.json). Bump it on
         // every TV release so the updater offers the new APK.
-        versionCode = 7
-        versionName = "1.2.3"
+        versionCode = 8
+        versionName = "1.2.4"
         ndk { abiFilters += listOf("armeabi-v7a", "arm64-v8a") }
     }
 

--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -14,6 +14,17 @@
          consent the first time; this permission is what lets us ask. -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
+    <!-- Package visibility (API 30+): the updater resolves the "install unknown
+         apps" consent screen before offering a button for it, and resolution is
+         filtered like any other cross-package lookup. Without this the match can
+         come back empty on some builds and a device that HAS the screen gets the
+         written directions instead. -->
+    <queries>
+        <intent>
+            <action android:name="android.settings.MANAGE_UNKNOWN_APP_SOURCES" />
+        </intent>
+    </queries>
+
     <!-- TV discovery: declare touchscreen optional, Leanback (10-foot UI) required -->
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
     <uses-feature android:name="android.software.leanback" android:required="true" />

--- a/app-tv/src/main/kotlin/com/puretv/twitch/tv/TvMainActivity.kt
+++ b/app-tv/src/main/kotlin/com/puretv/twitch/tv/TvMainActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.mutableStateOf
 import androidx.media3.common.util.UnstableApi
 import com.puretv.twitch.tv.data.AppSettingsStore
+import com.puretv.twitch.tv.update.TvUpdateManager
 import com.puretv.twitch.tv.ui.PureTvTvNavHost
 import com.puretv.twitch.tv.ui.theme.PureTvTvTheme
 import com.puretv.twitch.tv.ui.theme.ThemeVariant
@@ -73,6 +74,23 @@ class TvMainActivity : ComponentActivity() {
                 PureTvTvNavHost()
             }
         }
+    }
+
+    /**
+     * Picks the update back up after the viewer has been to system Settings to
+     * grant "install unknown apps".
+     *
+     * Nothing was downloaded before they left, by design, so there is no
+     * in-flight work to resume: this only re-reads consent and, if it is now
+     * granted, starts the install that was deferred. Without it the viewer
+     * returns to the very screen asking for the permission they just gave,
+     * which reads as the app having ignored them. Best-effort, and never worth
+     * taking the Activity down for.
+     */
+    override fun onResume() {
+        super.onResume()
+        runCatching { getKoin().get<TvUpdateManager>().refreshInstallConsent() }
+            .onFailure { Log.w(TAG, "Could not re-check install consent", it) }
     }
 
     override fun onDestroy() {

--- a/app-tv/src/main/kotlin/com/puretv/twitch/tv/ui/screens/TvHomeScreen.kt
+++ b/app-tv/src/main/kotlin/com/puretv/twitch/tv/ui/screens/TvHomeScreen.kt
@@ -178,10 +178,15 @@ fun TvHomeScreen(
             verticalArrangement = Arrangement.spacedBy(32.dp),
         ) {
             // Quality-of-life: a newer TV APK is available — one click jumps to
-            // Settings where the download & install lives. Only shows when the
-            // launch/Settings check actually found a newer build.
-            (updateState as? TvUpdateState.Available)?.let { available ->
-                UpdateBanner(available = available, onOpenSettings = onOpenSettings)
+            // Settings where the download & install lives. NeedsInstallConsent
+            // counts too: that is the state where the update is furthest along
+            // and most easily forgotten, since it is waiting on the viewer.
+            when (val u = updateState) {
+                is TvUpdateState.Available -> u.info.versionName
+                is TvUpdateState.NeedsInstallConsent -> u.info.versionName
+                else -> null
+            }?.let { versionName ->
+                UpdateBanner(versionName = versionName, onOpenSettings = onOpenSettings)
             }
 
             hero?.let { h ->
@@ -325,7 +330,7 @@ private fun heroMetaLine(stream: StreamInfo, followedLive: Boolean): String = bu
 
 /** Update-available banner: tertiary tonal strip, jumps to Settings to install. */
 @Composable
-private fun UpdateBanner(available: TvUpdateState.Available, onOpenSettings: () -> Unit) {
+private fun UpdateBanner(versionName: String, onOpenSettings: () -> Unit) {
     val c = PureTvTvTheme.colors
     Row(
         modifier = Modifier
@@ -337,7 +342,7 @@ private fun UpdateBanner(available: TvUpdateState.Available, onOpenSettings: () 
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Text(
-            "Update available: ${available.info.versionName}",
+            "Update available: $versionName",
             style = MaterialTheme.typography.titleMedium,
             color = c.onTertiaryContainer,
         )

--- a/app-tv/src/main/kotlin/com/puretv/twitch/tv/ui/screens/TvSettingsScreen.kt
+++ b/app-tv/src/main/kotlin/com/puretv/twitch/tv/ui/screens/TvSettingsScreen.kt
@@ -133,6 +133,7 @@ fun TvSettingsScreen(onBack: () -> Unit, viewModel: SettingsViewModel = koinView
                 state = updateState,
                 onCheck = { updateManager.checkForUpdates(force = true) },
                 onInstall = { info -> updateManager.downloadAndInstall(info) },
+                onGrantConsent = { updateManager.openInstallSettings() },
             )
         }
     }
@@ -319,6 +320,7 @@ private fun SoftwareUpdateSection(
     state: TvUpdateState,
     onCheck: () -> Unit,
     onInstall: (com.puretv.twitch.tv.update.TvUpdateInfo) -> Unit,
+    onGrantConsent: () -> Unit,
 ) {
     val c = PureTvTvTheme.colors
     Column {
@@ -356,6 +358,39 @@ private fun SoftwareUpdateSection(
                 Text(state.message, style = MaterialTheme.typography.bodyLarge, color = c.error)
                 Spacer(Modifier.height(16.dp))
                 TvExpressiveButton(text = "Try again", onClick = onCheck, style = TvButtonStyle.Outlined, icon = ExpressiveIcons.Refresh)
+            }
+            is TvUpdateState.NeedsInstallConsent -> {
+                Text(
+                    "Update ${state.info.versionName} is ready to install.",
+                    style = PureTvTvType.data,
+                    color = c.primary,
+                )
+                Spacer(Modifier.height(8.dp))
+                if (state.settingsResolvable) {
+                    // Nothing has been downloaded yet, so leaving for Settings
+                    // here costs nothing even if this app is stopped on the way.
+                    // Coming back re-checks consent and continues on its own.
+                    Text(
+                        "Android needs your permission before PureTV can install it. " +
+                            "Choose Allow on the next screen, then come back and the update will continue.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = c.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    TvExpressiveButton(text = "Allow and continue", onClick = onGrantConsent, icon = ExpressiveIcons.Download)
+                } else {
+                    // Fire OS publishes no per-app consent screen, so a button
+                    // would go nowhere. Directions are the only honest option.
+                    Text(
+                        "This device has no in-app permission screen. Open Settings, " +
+                            "then My Fire TV, then Developer options, and turn on " +
+                            "Install unknown apps for PureTV. Then come back and press Check for updates.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = c.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    TvExpressiveButton(text = "Check for updates", onClick = onCheck, style = TvButtonStyle.Outlined, icon = ExpressiveIcons.Refresh)
+                }
             }
             TvUpdateState.Idle ->
                 TvExpressiveButton(text = "Check for updates", onClick = onCheck, style = TvButtonStyle.Outlined, icon = ExpressiveIcons.Refresh)

--- a/app-tv/src/main/kotlin/com/puretv/twitch/tv/update/TvUpdateManager.kt
+++ b/app-tv/src/main/kotlin/com/puretv/twitch/tv/update/TvUpdateManager.kt
@@ -139,28 +139,36 @@ class TvUpdateManager(private val context: Context) {
      * this app holds nothing at all.
      */
     fun downloadAndInstall(info: TvUpdateInfo) {
-        when (_state.value) {
-            is TvUpdateState.Downloading, TvUpdateState.Installing -> return
-            else -> Unit
-        }
-        // Anti-downgrade before consent: someone already on the newest build must
-        // never be sent to Settings for an install that would then be refused.
-        when (updateGate(info.versionCode, currentVersionCode, hasInstallConsent())) {
-            UpdateGate.ALREADY_CURRENT -> {
-                _state.value = TvUpdateState.UpToDate
-                return
-            }
-            UpdateGate.NEEDS_INSTALL_CONSENT -> {
-                _state.value = TvUpdateState.NeedsInstallConsent(info, canOpenInstallSettings())
-                return
-            }
-            UpdateGate.READY_TO_INSTALL -> Unit
-        }
-        // Claimed before the coroutine starts, so a second caller cannot slip
-        // between the gate above and the first state write inside it.
+        // Claimed before anything else, so a second caller cannot slip between
+        // the gate and the first state write.
         if (!installInFlight.compareAndSet(false, true)) return
         scope.launch {
             try {
+                when (_state.value) {
+                    is TvUpdateState.Downloading, TvUpdateState.Installing -> return@launch
+                    else -> Unit
+                }
+                // The gate itself runs here rather than on the caller's thread.
+                // Every branch of it reads the package manager (getPackageInfo,
+                // canRequestPackageInstalls, and up to two queryIntentActivities),
+                // and the caller is a button press on the main thread. Those are
+                // binder round-trips and this is the primary user-initiated path,
+                // which is exactly where they must not block the frame.
+                //
+                // Anti-downgrade before consent: someone already on the newest
+                // build must never be sent to Settings for an install that would
+                // then be refused.
+                when (updateGate(info.versionCode, currentVersionCode, hasInstallConsent())) {
+                    UpdateGate.ALREADY_CURRENT -> {
+                        _state.value = TvUpdateState.UpToDate
+                        return@launch
+                    }
+                    UpdateGate.NEEDS_INSTALL_CONSENT -> {
+                        _state.value = TvUpdateState.NeedsInstallConsent(info, canOpenInstallSettings())
+                        return@launch
+                    }
+                    UpdateGate.READY_TO_INSTALL -> Unit
+                }
                 runCatching {
                     _state.value = TvUpdateState.Downloading(0f)
                     val apk = downloadApk(info)
@@ -203,11 +211,27 @@ class TvUpdateManager(private val context: Context) {
      * broken. Either way they never land back on the consent screen.
      */
     fun refreshInstallConsent() {
-        val pending = _state.value as? TvUpdateState.NeedsInstallConsent ?: return
-        // canRequestPackageInstalls is a binder call and this runs on onResume,
-        // so it does not belong on the main thread.
-        scope.launch { if (hasInstallConsent()) downloadAndInstall(pending.info) }
+        // All of this touches the package manager, and onResume is the main
+        // thread, so none of it is done here.
+        scope.launch {
+            // A confirm dialog whose result never reached the receiver leaves
+            // Installing set for the rest of the process, and every other entry
+            // point declines to leave that state, so the Settings screen would
+            // show a spinner forever. Being foregrounded again with none of our
+            // own sessions still open is good evidence it is over, however it
+            // ended.
+            if (_state.value == TvUpdateState.Installing && !hasOpenSession()) {
+                _state.value = TvUpdateState.Idle
+            }
+            val pending = _state.value as? TvUpdateState.NeedsInstallConsent ?: return@launch
+            if (hasInstallConsent()) downloadAndInstall(pending.info)
+        }
     }
+
+    /** Whether any install session of ours is still open. */
+    private fun hasOpenSession(): Boolean = runCatching {
+        context.packageManager.packageInstaller.mySessions.isNotEmpty()
+    }.getOrDefault(false)
 
     /** Whether the OS will let us commit an install session for our own package. */
     private fun hasInstallConsent(): Boolean =
@@ -246,18 +270,31 @@ class TvUpdateManager(private val context: Context) {
     /**
      * Resolved rather than attempted, so the UI can offer written directions on
      * a set where the screen does not exist instead of a button that does
-     * nothing. queryIntentActivities (not resolveActivity) because it stays
-     * accurate under API 30+ package visibility.
+     * nothing. Package-visibility filtering applies to this the same way it
+     * applies to resolveActivity, so the manifest declares a <queries> entry for
+     * the action; without it an OEM build could filter the match and downgrade a
+     * capable device to the directions text.
      */
     private fun canOpenInstallSettings(): Boolean = resolvableInstallSettings() != null
 
     /**
-     * Sends the viewer to the consent screen. Returns false when there was
-     * nowhere to send them, which the caller shows as instructions.
+     * Sends the viewer to the consent screen.
+     *
+     * When there is nowhere to send them, or the launch is refused, the state
+     * drops to the written-directions variant rather than leaving a button that
+     * silently does nothing on the one screen this whole change exists to serve.
+     * settingsResolvable was decided at gate time and the launch can still fail
+     * after it, so this is the only place that failure can be caught.
      */
-    fun openInstallSettings(): Boolean {
-        val intent = resolvableInstallSettings() ?: return false
-        return runCatching { context.startActivity(intent); true }.getOrDefault(false)
+    fun openInstallSettings() {
+        scope.launch {
+            val intent = resolvableInstallSettings()
+            val launched = intent != null &&
+                runCatching { context.startActivity(intent); true }.getOrDefault(false)
+            if (launched) return@launch
+            val pending = _state.value as? TvUpdateState.NeedsInstallConsent ?: return@launch
+            _state.value = pending.copy(settingsResolvable = false)
+        }
     }
 
     /**
@@ -270,6 +307,15 @@ class TvUpdateManager(private val context: Context) {
         runCatching {
             val installer = context.packageManager.packageInstaller
             installer.mySessions.forEach { session ->
+                // A committed session is waiting on the system confirm dialog,
+                // which outlives this process. Abandoning that would cancel an
+                // install the viewer is being asked about right now, so only
+                // sessions still open for writing are swept. isCommitted arrived
+                // in API 29; below it the distinction is not observable, and
+                // there the leak is the worse of the two problems.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && session.isCommitted) {
+                    return@forEach
+                }
                 runCatching { installer.abandonSession(session.sessionId) }
                     .onFailure { Log.w(TAG, "Could not abandon stale install session ${session.sessionId}", it) }
             }

--- a/app-tv/src/main/kotlin/com/puretv/twitch/tv/update/TvUpdateManager.kt
+++ b/app-tv/src/main/kotlin/com/puretv/twitch/tv/update/TvUpdateManager.kt
@@ -168,11 +168,14 @@ class TvUpdateManager(private val context: Context) {
      * Call this whenever the app comes back to the foreground. The viewer who
      * grants consent in Settings and returns must not land back on the same
      * "grant permission" screen they just satisfied, which is indistinguishable
-     * from the app having ignored them. Two returns are possible and this covers
-     * both: if the process survived the detour, the state is still
-     * [TvUpdateState.NeedsInstallConsent] and we continue from it; if it did not,
-     * start-up's own [checkForUpdates] finds the update again and the install
-     * proceeds with consent already in hand.
+     * from the app having ignored them.
+     *
+     * This only auto-continues when the process survived the detour, since it
+     * needs the pending state to still be here. If the process was killed,
+     * start-up's own [checkForUpdates] surfaces the update again and the viewer
+     * presses install once more: that attempt then passes the consent gate
+     * instead of dead-ending at the installer, which is the part that was
+     * broken. Either way they never land back on the consent screen.
      */
     fun refreshInstallConsent() {
         val pending = _state.value as? TvUpdateState.NeedsInstallConsent ?: return
@@ -190,9 +193,30 @@ class TvUpdateManager(private val context: Context) {
      * Google TV; absent on Fire OS, which keeps the equivalent toggle under
      * Developer options and does not publish this Intent at all.
      */
-    private fun installSettingsIntent(): Intent =
-        Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES, Uri.parse("package:${context.packageName}"))
+    private fun packageScopedInstallSettings(): Intent =
+        Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES, Uri.parse("package:" + context.packageName))
             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    private fun bareInstallSettings(): Intent =
+        Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    /**
+     * The first of the two forms this device actually resolves, or null when it
+     * publishes neither.
+     *
+     * Both are probed because intent resolution only matches a filter that
+     * declares a `<data>` scheme when the Intent carries a URI. A build whose
+     * Settings activity declares the action without `scheme="package"` resolves
+     * the bare form and NOT the package-scoped one, which would otherwise be
+     * read as "this device has no consent screen" and downgrade a working set to
+     * the written directions. Package-scoped is tried first because it lands
+     * directly on this app's row instead of a list to hunt through.
+     */
+    private fun resolvableInstallSettings(): Intent? = runCatching {
+        listOf(packageScopedInstallSettings(), bareInstallSettings())
+            .firstOrNull { context.packageManager.queryIntentActivities(it, 0).isNotEmpty() }
+    }.getOrNull()
 
     /**
      * Resolved rather than attempted, so the UI can offer written directions on
@@ -200,18 +224,16 @@ class TvUpdateManager(private val context: Context) {
      * nothing. queryIntentActivities (not resolveActivity) because it stays
      * accurate under API 30+ package visibility.
      */
-    private fun canOpenInstallSettings(): Boolean = runCatching {
-        context.packageManager.queryIntentActivities(installSettingsIntent(), 0).isNotEmpty()
-    }.getOrDefault(false)
+    private fun canOpenInstallSettings(): Boolean = resolvableInstallSettings() != null
 
     /**
      * Sends the viewer to the consent screen. Returns false when there was
      * nowhere to send them, which the caller shows as instructions.
      */
-    fun openInstallSettings(): Boolean = runCatching {
-        context.startActivity(installSettingsIntent())
-        true
-    }.getOrDefault(false)
+    fun openInstallSettings(): Boolean {
+        val intent = resolvableInstallSettings() ?: return false
+        return runCatching { context.startActivity(intent); true }.getOrDefault(false)
+    }
 
     /**
      * Drops every install session this app owns. Deliberately not filtered by

--- a/app-tv/src/main/kotlin/com/puretv/twitch/tv/update/TvUpdateManager.kt
+++ b/app-tv/src/main/kotlin/com/puretv/twitch/tv/update/TvUpdateManager.kt
@@ -6,6 +6,10 @@ import android.content.Intent
 import android.content.pm.PackageInstaller
 import android.net.Uri
 import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import com.puretv.twitch.core.update.UpdateGate
+import com.puretv.twitch.core.update.updateGate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -61,6 +65,18 @@ class TvUpdateManager(private val context: Context) {
     private fun packageInfo() = context.packageManager.getPackageInfo(context.packageName, 0)
 
     init {
+        // Anything still open belongs to an update that did not finish: a
+        // successful one replaces this process, so a surviving session by
+        // definition did not succeed. They are never resumed, and the OS caps how
+        // many an installer may hold, so sweeping at start-up is what keeps a
+        // string of interrupted updates from eventually making createSession fail.
+        //
+        // On `scope` (IO) rather than inline: this singleton can first be resolved
+        // from the Activity's onResume, on the main thread, and mySessions and
+        // abandonSession are binder calls. Construction stays cheap wherever it
+        // happens, which is the same rule the rest of start-up follows.
+        scope.launch { abandonOrphanedSessions() }
+
         // Surface a failed system-side install (the user cancelled the confirm
         // dialog, signature mismatch, etc.) back into our UI. Success replaces the
         // running app, so there's nothing to show for it.
@@ -94,17 +110,36 @@ class TvUpdateManager(private val context: Context) {
         }
     }
 
-    /** Downloads [info]'s APK and launches the system installer. */
+    /**
+     * Downloads [info]'s APK and launches the system installer, but only once
+     * the OS has agreed to let us install at all.
+     *
+     * The consent check happens HERE, before the download and before any
+     * session exists, and that ordering is the fix for a reported dead app
+     * rather than a tidiness preference. A sideloaded app has no "install
+     * unknown apps" consent until the viewer grants it, and granting it means
+     * leaving for system Settings. Committing a session first meant that detour
+     * started with an APK on disk and a live installer session, and the app did
+     * not reliably come back from it. Asking first means the viewer leaves while
+     * this app holds nothing at all.
+     */
     fun downloadAndInstall(info: TvUpdateInfo) {
         when (_state.value) {
             is TvUpdateState.Downloading, TvUpdateState.Installing -> return
             else -> Unit
         }
-        // Anti-downgrade: never install something that isn't strictly newer, even
-        // if the manifest was edited to point at an older APK.
-        if (info.versionCode <= currentVersionCode) {
-            _state.value = TvUpdateState.UpToDate
-            return
+        // Anti-downgrade before consent: someone already on the newest build must
+        // never be sent to Settings for an install that would then be refused.
+        when (updateGate(info.versionCode, currentVersionCode, hasInstallConsent())) {
+            UpdateGate.ALREADY_CURRENT -> {
+                _state.value = TvUpdateState.UpToDate
+                return
+            }
+            UpdateGate.NEEDS_INSTALL_CONSENT -> {
+                _state.value = TvUpdateState.NeedsInstallConsent(info, canOpenInstallSettings())
+                return
+            }
+            UpdateGate.READY_TO_INSTALL -> Unit
         }
         scope.launch {
             runCatching {
@@ -121,9 +156,77 @@ class TvUpdateManager(private val context: Context) {
     /** Reset a terminal error / "up to date" back to idle (e.g. dismiss a banner). */
     fun dismiss() {
         when (_state.value) {
-            is TvUpdateState.Error, TvUpdateState.UpToDate -> _state.value = TvUpdateState.Idle
+            is TvUpdateState.Error, TvUpdateState.UpToDate, is TvUpdateState.NeedsInstallConsent ->
+                _state.value = TvUpdateState.Idle
             else -> Unit
         }
+    }
+
+    /**
+     * Re-evaluates consent and resumes on its own if it has since been granted.
+     *
+     * Call this whenever the app comes back to the foreground. The viewer who
+     * grants consent in Settings and returns must not land back on the same
+     * "grant permission" screen they just satisfied, which is indistinguishable
+     * from the app having ignored them. Two returns are possible and this covers
+     * both: if the process survived the detour, the state is still
+     * [TvUpdateState.NeedsInstallConsent] and we continue from it; if it did not,
+     * start-up's own [checkForUpdates] finds the update again and the install
+     * proceeds with consent already in hand.
+     */
+    fun refreshInstallConsent() {
+        val pending = _state.value as? TvUpdateState.NeedsInstallConsent ?: return
+        // canRequestPackageInstalls is a binder call and this runs on onResume,
+        // so it does not belong on the main thread.
+        scope.launch { if (hasInstallConsent()) downloadAndInstall(pending.info) }
+    }
+
+    /** Whether the OS will let us commit an install session for our own package. */
+    private fun hasInstallConsent(): Boolean =
+        runCatching { context.packageManager.canRequestPackageInstalls() }.getOrDefault(false)
+
+    /**
+     * The per-app "install unknown apps" screen. Present on stock Android and
+     * Google TV; absent on Fire OS, which keeps the equivalent toggle under
+     * Developer options and does not publish this Intent at all.
+     */
+    private fun installSettingsIntent(): Intent =
+        Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES, Uri.parse("package:${context.packageName}"))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    /**
+     * Resolved rather than attempted, so the UI can offer written directions on
+     * a set where the screen does not exist instead of a button that does
+     * nothing. queryIntentActivities (not resolveActivity) because it stays
+     * accurate under API 30+ package visibility.
+     */
+    private fun canOpenInstallSettings(): Boolean = runCatching {
+        context.packageManager.queryIntentActivities(installSettingsIntent(), 0).isNotEmpty()
+    }.getOrDefault(false)
+
+    /**
+     * Sends the viewer to the consent screen. Returns false when there was
+     * nowhere to send them, which the caller shows as instructions.
+     */
+    fun openInstallSettings(): Boolean = runCatching {
+        context.startActivity(installSettingsIntent())
+        true
+    }.getOrDefault(false)
+
+    /**
+     * Drops every install session this app owns. Deliberately not filtered by
+     * `appPackageName`: a session abandoned before it was fully configured
+     * reports that field as null, and those are precisely the orphans worth
+     * clearing. `mySessions` is already scoped to this installer.
+     */
+    private fun abandonOrphanedSessions() {
+        runCatching {
+            val installer = context.packageManager.packageInstaller
+            installer.mySessions.forEach { session ->
+                runCatching { installer.abandonSession(session.sessionId) }
+                    .onFailure { Log.w(TAG, "Could not abandon stale install session ${session.sessionId}", it) }
+            }
+        }.onFailure { Log.w(TAG, "Could not enumerate install sessions", it) }
     }
 
     private fun fetchLatest(): TvUpdateInfo? {
@@ -213,6 +316,7 @@ class TvUpdateManager(private val context: Context) {
     }
 
     private companion object {
+        const val TAG = "TvUpdateManager"
         const val VERSION_MANIFEST_URL =
             "https://github.com/dhawal-ss/puretv/releases/download/tv-latest/tv-version.json"
     }
@@ -235,6 +339,21 @@ sealed interface TvUpdateState {
     data class Downloading(val progress: Float) : TvUpdateState
     data object Installing : TvUpdateState
     data class Error(val message: String) : TvUpdateState
+
+    /**
+     * A newer build is ready but the OS will not install it until the viewer
+     * grants "install unknown apps". Reached before anything is downloaded, so
+     * leaving for Settings from here costs nothing if the process does not
+     * survive the trip.
+     *
+     * [settingsResolvable] is false on sets that do not publish the per-app
+     * consent screen (Fire OS keeps it under Developer options), where the UI
+     * must print directions instead of offering a button that goes nowhere.
+     */
+    data class NeedsInstallConsent(
+        val info: TvUpdateInfo,
+        val settingsResolvable: Boolean,
+    ) : TvUpdateState
 }
 
 /**

--- a/app-tv/src/main/kotlin/com/puretv/twitch/tv/update/TvUpdateManager.kt
+++ b/app-tv/src/main/kotlin/com/puretv/twitch/tv/update/TvUpdateManager.kt
@@ -23,6 +23,7 @@ import okhttp3.Request
 import org.json.JSONObject
 import java.io.File
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * SECTION 09 — in-app updater for the sideloaded TV APK, over GitHub Releases.
@@ -48,6 +49,20 @@ class TvUpdateManager(private val context: Context) {
         .connectTimeout(15, TimeUnit.SECONDS)
         .readTimeout(60, TimeUnit.SECONDS)
         .build()
+
+    /**
+     * Claims the install path exactly once.
+     *
+     * The state check below is read-then-write and therefore racy, and this
+     * change made the race reachable: [refreshInstallConsent] fires from
+     * onResume, which can run more than once in quick succession, and a TV
+     * remote's OK button is easy to press twice. Two callers could both read
+     * a non-installing state before either wrote [TvUpdateState.Downloading],
+     * and the loser used to go on to a second download and a second committed
+     * session. Sessions that overlap like that are precisely what this change
+     * exists to stop leaving behind.
+     */
+    private val installInFlight = AtomicBoolean(false)
 
     private val _state = MutableStateFlow<TvUpdateState>(TvUpdateState.Idle)
     val state: StateFlow<TvUpdateState> = _state.asStateFlow()
@@ -141,14 +156,24 @@ class TvUpdateManager(private val context: Context) {
             }
             UpdateGate.READY_TO_INSTALL -> Unit
         }
+        // Claimed before the coroutine starts, so a second caller cannot slip
+        // between the gate above and the first state write inside it.
+        if (!installInFlight.compareAndSet(false, true)) return
         scope.launch {
-            runCatching {
-                _state.value = TvUpdateState.Downloading(0f)
-                val apk = downloadApk(info)
-                _state.value = TvUpdateState.Installing
-                installApk(apk)
-            }.onFailure { e ->
-                _state.value = TvUpdateState.Error(e.message ?: "Update failed.")
+            try {
+                runCatching {
+                    _state.value = TvUpdateState.Downloading(0f)
+                    val apk = downloadApk(info)
+                    _state.value = TvUpdateState.Installing
+                    installApk(apk)
+                }.onFailure { e ->
+                    _state.value = TvUpdateState.Error(e.message ?: "Update failed.")
+                }
+            } finally {
+                // By here the state is Installing (the system confirm dialog is
+                // up, and the ordinary guard blocks re-entry) or Error (a retry
+                // is exactly what should be allowed), so releasing is safe.
+                installInFlight.set(false)
             }
         }
     }

--- a/core/src/commonMain/kotlin/com/puretv/twitch/core/update/UpdateGate.kt
+++ b/core/src/commonMain/kotlin/com/puretv/twitch/core/update/UpdateGate.kt
@@ -1,0 +1,49 @@
+package com.puretv.twitch.core.update
+
+/**
+ * The decision both Android updaters make BEFORE touching the network or the
+ * system installer, lifted out of them so it can be tested off-device.
+ *
+ * The ordering is the whole point. Consent is settled before anything is
+ * downloaded and before any [android.content.pm.PackageInstaller] session
+ * exists, so the consent detour, which sends the viewer into system Settings
+ * and can take this process down on the way, happens while the app is holding
+ * nothing that a kill could corrupt or leak. Committing a session first and
+ * discovering the consent gap afterwards is what put a half-finished update and
+ * an orphaned session on the other side of that kill.
+ *
+ * Everything here is a plain value. The platform calls that produce those
+ * values (`canRequestPackageInstalls`, `longVersionCode`) stay in the app
+ * modules, which is why this file has no Android imports and app-tv, which has
+ * no test source set of its own, still gets covered.
+ */
+enum class UpdateGate {
+    /** Nothing newer is published, or a manifest points backwards. */
+    ALREADY_CURRENT,
+
+    /**
+     * A newer build exists, but the OS will refuse to install it until the
+     * viewer grants "install unknown apps". Ask first, download nothing.
+     */
+    NEEDS_INSTALL_CONSENT,
+
+    /** Newer build, consent in hand: safe to download and commit. */
+    READY_TO_INSTALL,
+}
+
+/**
+ * [candidateVersionCode] is the manifest's; [installedVersionCode] is what is
+ * running. The downgrade check comes first deliberately: an edited or rolled
+ * back manifest must be refused whether or not consent was ever granted, so
+ * that a viewer who is already current is never sent into Settings for an
+ * install that would then be rejected as a downgrade.
+ */
+fun updateGate(
+    candidateVersionCode: Long,
+    installedVersionCode: Long,
+    hasInstallConsent: Boolean,
+): UpdateGate = when {
+    candidateVersionCode <= installedVersionCode -> UpdateGate.ALREADY_CURRENT
+    !hasInstallConsent -> UpdateGate.NEEDS_INSTALL_CONSENT
+    else -> UpdateGate.READY_TO_INSTALL
+}

--- a/core/src/commonTest/kotlin/com/puretv/twitch/core/update/UpdateGateTest.kt
+++ b/core/src/commonTest/kotlin/com/puretv/twitch/core/update/UpdateGateTest.kt
@@ -1,0 +1,75 @@
+package com.puretv.twitch.core.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers the ordering that keeps the consent detour off the dangerous path.
+ *
+ * A TV viewer reported the app refusing to start after tapping update: the
+ * installer asked for "install unknown apps" only once a session had already
+ * been committed, so granting it sent them through system Settings while a
+ * download and an installer session were live. These assertions pin the
+ * decision that has to happen before any of that exists.
+ */
+class UpdateGateTest {
+
+    @Test
+    fun consentIsDemandedBeforeAnythingIsDownloaded() {
+        assertEquals(
+            UpdateGate.NEEDS_INSTALL_CONSENT,
+            updateGate(candidateVersionCode = 7, installedVersionCode = 6, hasInstallConsent = false),
+            "a newer build without consent must stop at the gate, not at the installer",
+        )
+    }
+
+    @Test
+    fun consentInHandProceeds() {
+        assertEquals(
+            UpdateGate.READY_TO_INSTALL,
+            updateGate(candidateVersionCode = 7, installedVersionCode = 6, hasInstallConsent = true),
+        )
+    }
+
+    @Test
+    fun sameVersionIsCurrentRatherThanAnInstall() {
+        assertEquals(
+            UpdateGate.ALREADY_CURRENT,
+            updateGate(candidateVersionCode = 7, installedVersionCode = 7, hasInstallConsent = true),
+        )
+    }
+
+    /**
+     * The downgrade check outranks the consent check. Were the order reversed, a
+     * viewer already on the newest build and lacking consent would be sent into
+     * Settings to authorise an install the anti-downgrade rule then refuses,
+     * which is a dead end that looks exactly like the bug this change fixes.
+     */
+    @Test
+    fun aBackwardsManifestIsRefusedWithoutSendingAnyoneToSettings() {
+        assertEquals(
+            UpdateGate.ALREADY_CURRENT,
+            updateGate(candidateVersionCode = 6, installedVersionCode = 7, hasInstallConsent = false),
+        )
+        assertEquals(
+            UpdateGate.ALREADY_CURRENT,
+            updateGate(candidateVersionCode = 6, installedVersionCode = 7, hasInstallConsent = true),
+        )
+    }
+
+    /**
+     * versionCode is a Long on purpose: the updater reads `longVersionCode`, and
+     * a value past Int range must not wrap into a downgrade.
+     */
+    @Test
+    fun largeVersionCodesDoNotWrap() {
+        assertEquals(
+            UpdateGate.READY_TO_INSTALL,
+            updateGate(
+                candidateVersionCode = Int.MAX_VALUE.toLong() + 1L,
+                installedVersionCode = Int.MAX_VALUE.toLong(),
+                hasInstallConsent = true,
+            ),
+        )
+    }
+}

--- a/docs/android-version.json
+++ b/docs/android-version.json
@@ -1,6 +1,6 @@
 {
-  "versionCode": 6,
-  "versionName": "1.1.2",
+  "versionCode": 7,
+  "versionName": "1.1.3",
   "apkUrl": "https://github.com/dhawal-ss/puretv/releases/download/android-latest/PureTV-for-Twitch-Android.apk",
-  "notes": "The sign-in screens scroll now, so the activation code stays reachable in landscape and in split-screen instead of sitting below the bottom of the window. Start-up is sturdier: the theme no longer loads during the first frame, and unreadable settings or a lost sign-in are now cleared and recovered from instead of stopping the app."
+  "notes": "Updating is fixed. The app used to start downloading an update and only then ask Android for permission to install it, which interrupted the update part-way through and could leave the app unable to open afterwards. Permission is now asked for first, before anything is downloaded, and once you allow it the update carries on by itself. Unfinished update attempts are also cleared away instead of piling up."
 }

--- a/docs/tv-version.json
+++ b/docs/tv-version.json
@@ -1,6 +1,6 @@
 {
-  "versionCode": 7,
-  "versionName": "1.2.3",
+  "versionCode": 8,
+  "versionName": "1.2.4",
   "apkUrl": "https://github.com/dhawal-ss/puretv/releases/download/tv-latest/PureTV-FireTV-AndroidTV.apk",
-  "notes": "When a stream cannot be loaded, the app now says why instead of showing a black screen. It also catches a case where Twitch refused the stream but the app treated the refusal as success, which left the player with nothing to play and no way to report it. Press OK to try again."
+  "notes": "Updating is fixed. The app used to start downloading an update and only then ask Android for permission to install it, which interrupted the update part-way through and could leave the app unable to open afterwards. Permission is now asked for first, before anything is downloaded, and once you allow it the update carries on by itself. Unfinished update attempts are also cleared away instead of piling up."
 }


### PR DESCRIPTION
Fixes the reported flow: tap update, get told the install is not allowed, grant "install unknown apps" in Settings, come back to an app that will not start. Same shape was reported on 1.2.1, and two rounds of start-up hardening did not stop it because both treated the symptom.

Closes nothing yet, see the caveat at the bottom.

## The change

`downloadAndInstall` committed a `PackageInstaller` session and let the OS discover the missing consent. That ordering puts the viewer in system Settings at the exact moment the app is holding a downloaded APK and a live installer session, and the consent detour can take the process down with it.

Consent is now settled **first**, before a byte is fetched and before any session exists, so leaving for Settings costs nothing whichever way the trip ends.

- **`core/update/UpdateGate.kt`** holds the decision as a pure function. That is also the only way app-tv gets coverage, since it has no test source set of its own. 5 new tests, `:core:desktopTest` now 175 passing.
- **Anti-downgrade outranks consent.** Reversed, a viewer already on the newest build without consent would be sent to Settings to authorise an install the downgrade rule then refuses: the same dead end wearing a different hat. Pinned by a test.
- **`onResume` re-reads consent on both apps.** The viewer never lands back on the screen asking for what they just granted, which is the loop the report describes. It auto-continues the install only when the process survived the detour; if it was killed, start-up re-surfaces the update and the next press passes the consent gate instead of dead-ending at the installer, which is the part that was broken.
- **Sessions are swept at start-up.** A successful install replaces the process, so a surviving session did not succeed, and none are ever resumed. The OS caps how many an installer may hold. Not filtered by `appPackageName`, because a session abandoned before it was fully configured reports that as null and those are exactly the orphans worth clearing.
- **Fire OS has no per-app consent screen**, so the Intent is resolved rather than attempted and the UI prints directions where a button would go nowhere. Both the package-scoped and bare Intent forms are probed: resolution only matches a `<data>` scheme filter when the Intent carries a URI, so probing only the scoped form would silently downgrade a capable device to the directions text.
- Binder calls (`mySessions`, `canRequestPackageInstalls`) run on IO, since `onResume` can be the first thing to resolve the singleton.

## Scope

`app-windows` is untouched. Its updater verifies a signed installer and hands off to a detached script, so it shares none of this shape.

## What this does not claim

The wiring is **compile-verified, not device-verified**. The connection to the app failing to *launch* is inference: this removes the window in which a process kill can land on in-flight install work, which is the most likely trigger, but if the crash has a cause unrelated to install timing this will not touch it.

A logcat from a set in the failed state is still what settles it, and is worth capturing before this is released.

## Bootstrapping caveat

A fix to the updater cannot reach anyone already stuck, since reaching them requires the updater. Anyone bricked recovers by sideloading either way. That argues for getting this right over getting it out fast.
