### PR TITLE
Stop the mock request counters losing increments

### DIFF
--- a/core/src/commonTest/kotlin/com/puretv/twitch/core/CallCounter.kt
+++ b/core/src/commonTest/kotlin/com/puretv/twitch/core/CallCounter.kt
@@ -1,0 +1,36 @@
+package com.puretv.twitch.core
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A request counter that is safe to bump from inside a Ktor `MockEngine`
+ * handler.
+ *
+ * Several services under test fan their requests out with `async`
+ * (`FollowedChannelsService` chunks /streams and /users, `EmoteRepository`
+ * loads its providers side by side), so the handler runs on more than one
+ * thread and a plain `var n = 0` loses increments.
+ *
+ * That is not hypothetical. CI failed on
+ * `paginatesFollowsChunksLiveAndProfilesThenMerges` with
+ * `120 ids must be chunked into 2 /users calls expected:<2> but was:<1>`,
+ * while every data assertion in the same test passed and the identically
+ * chunked /streams counter read 2. Both requests were made; one increment was
+ * simply lost. The same test had passed twice on the same commit minutes
+ * earlier, which is the tell: a logic error would fail every time, a lost
+ * update fails on whichever machine happens to interleave.
+ *
+ * [incrementAndGet] returns the value it just stored, so a handler that
+ * branches on "is this the first call?" reads its own increment rather than
+ * re-reading a field another thread may have moved.
+ */
+class CallCounter {
+    private val lock = Mutex()
+    private var value = 0
+
+    suspend fun incrementAndGet(): Int = lock.withLock { ++value }
+
+    /** Read under the same lock, so the assertion cannot race the last write. */
+    suspend fun get(): Int = lock.withLock { value }
+}

--- a/core/src/commonTest/kotlin/com/puretv/twitch/core/emotes/EmoteRepositoryGlobalLoadTest.kt
+++ b/core/src/commonTest/kotlin/com/puretv/twitch/core/emotes/EmoteRepositoryGlobalLoadTest.kt
@@ -1,5 +1,6 @@
 package com.puretv.twitch.core.emotes
 
+import com.puretv.twitch.core.CallCounter
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -19,13 +20,15 @@ class EmoteRepositoryGlobalLoadTest {
     private val bttvGlobal = """[{"id":"b1","code":"FeelsGood","imageType":"png"}]"""
 
     @Test fun transientBttvFailureDoesNotPoisonTheSession() = runTest {
-        var bttvCalls = 0
+        // EmoteRepository loads its providers with async, so this handler runs on
+        // more than one thread. incrementAndGet reads back the value it just
+        // stored, which is what the first-call branch below needs.
+        val bttvCalls = CallCounter()
         val engine = MockEngine { request ->
             val url = request.url.toString()
             when {
                 "betterttv" in url -> {
-                    bttvCalls++
-                    if (bttvCalls == 1) respond("err", HttpStatusCode.InternalServerError)
+                    if (bttvCalls.incrementAndGet() == 1) respond("err", HttpStatusCode.InternalServerError)
                     else respond(bttvGlobal, HttpStatusCode.OK, jsonHeaders)
                 }
                 "7tv.io" in url -> respond(sevenTvGlobal, HttpStatusCode.OK, jsonHeaders)

--- a/core/src/commonTest/kotlin/com/puretv/twitch/core/follows/FollowedChannelsServiceTest.kt
+++ b/core/src/commonTest/kotlin/com/puretv/twitch/core/follows/FollowedChannelsServiceTest.kt
@@ -1,5 +1,6 @@
 package com.puretv.twitch.core.follows
 
+import com.puretv.twitch.core.CallCounter
 import com.puretv.twitch.core.api.TwitchApiClient
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -45,8 +46,10 @@ class FollowedChannelsServiceTest {
     }
 
     @Test fun paginatesFollowsChunksLiveAndProfilesThenMerges() = runTest {
-        var streamCalls = 0
-        var userCalls = 0
+        // Counted under a lock: the service fetches these chunks with async, so
+        // the handler below runs on more than one thread.
+        val streamCalls = CallCounter()
+        val userCalls = CallCounter()
         val engine = MockEngine { request ->
             val url = request.url
             when {
@@ -56,11 +59,11 @@ class FollowedChannelsServiceTest {
                     else respond(followsPage(followLogins.drop(100), null), HttpStatusCode.OK, jsonHeaders)
                 }
                 url.encodedPath.endsWith("/streams") -> {
-                    streamCalls++
+                    streamCalls.incrementAndGet()
                     respond(streamsFor(url.parameters.getAll("user_login").orEmpty()), HttpStatusCode.OK, jsonHeaders)
                 }
                 url.encodedPath.endsWith("/users") -> {
-                    userCalls++
+                    userCalls.incrementAndGet()
                     respond(usersFor(url.parameters.getAll("id").orEmpty()), HttpStatusCode.OK, jsonHeaders)
                 }
                 else -> respond("", HttpStatusCode.NotFound)
@@ -75,8 +78,8 @@ class FollowedChannelsServiceTest {
 
         assertEquals(3, result.live.size, "3 followed channels are live")
         assertEquals(117, result.offline.size, "the rest are offline")
-        assertEquals(2, streamCalls, "120 logins must be chunked into 2 /streams calls (100 + 20)")
-        assertEquals(2, userCalls, "120 ids must be chunked into 2 /users calls (100 + 20)")
+        assertEquals(2, streamCalls.get(), "120 logins must be chunked into 2 /streams calls (100 + 20)")
+        assertEquals(2, userCalls.get(), "120 ids must be chunked into 2 /users calls (100 + 20)")
         // Live sorted by viewers desc: c2 (102) > c1 (101) > c0 (100)
         assertEquals(listOf("c2", "c1", "c0"), result.live.map { it.login })
         assertEquals("http://a/c2.png", result.live.first().avatarUrl)
@@ -173,14 +176,14 @@ class FollowedChannelsServiceTest {
     }
 
     @Test fun secondLoadReusesCachedProfilesAndSkipsUsersCall() = runTest {
-        var userCalls = 0
+        val userCalls = CallCounter()
         val engine = MockEngine { request ->
             val url = request.url
             when {
                 url.encodedPath.endsWith("/channels/followed") -> respond(followsPage(listOf("c0", "c1"), null), HttpStatusCode.OK, jsonHeaders)
                 url.encodedPath.endsWith("/streams") -> respond(streamsFor(url.parameters.getAll("user_login").orEmpty()), HttpStatusCode.OK, jsonHeaders)
                 url.encodedPath.endsWith("/users") -> {
-                    userCalls++
+                    userCalls.incrementAndGet()
                     respond(usersFor(url.parameters.getAll("id").orEmpty()), HttpStatusCode.OK, jsonHeaders)
                 }
                 else -> respond("", HttpStatusCode.NotFound)
@@ -194,7 +197,7 @@ class FollowedChannelsServiceTest {
         service.load("user123", localPins = emptyList()) {}          // first load populates the profile cache
         val second = service.load("user123", localPins = emptyList()) {}
 
-        assertEquals(1, userCalls, "profiles are cached: the second load must not re-fetch /users")
+        assertEquals(1, userCalls.get(), "profiles are cached: the second load must not re-fetch /users")
         // The cached profile is still applied on the second pass.
         assertEquals("http://a/c0.png", (second.live + second.offline).first { it.login == "c0" }.avatarUrl)
     }


### PR DESCRIPTION
CI went red on `main` at 43b12b2 with:

```
120 ids must be chunked into 2 /users calls (100 + 20) expected:<2> but was:<1>
```

The same commit's CI had passed twice minutes earlier on the PR, and nothing in that change touches follows.

## What actually happened

Both requests were made. `FollowedChannelsService` fans its chunks out with `async` (`FollowedChannelsService.kt:69-75`), so the `MockEngine` handler runs on more than one thread, and the test counted calls with a plain `var n = 0`. Two threads read the same value and wrote back the same value; one increment vanished.

Three things in that same run show it is the counter and not the service:

- `streamCalls` went through the **identical** `chunked(100)` path on the same 120 items and read `2`.
- Every data assertion before the failure passed, including `offline.size == 117`.
- It is nondeterministic. A logic error fails on every machine; a lost update fails on whichever one happens to interleave.

## The fix

A shared `CallCounter` guards the read-modify-write with a `Mutex` and reads under the same lock, so the assertion cannot race the final write.

- Applied to all three counters in `FollowedChannelsServiceTest`.
- Applied to `EmoteRepositoryGlobalLoadTest`: `EmoteRepository` fans out the same way, and its first-call branch reads the counter it just bumped. `incrementAndGet` returns the value it stored, so that branch cannot observe another thread's write.
- **Not** applied to `FollowedChannelsPaginationTest` or `UserRepositoryFollowsTest`. `TwitchApiClient` and `UserRepository` contain no `async`, so those handlers are only ever entered sequentially and there is nothing to race.

## Scope

Tests only. No shipped code changes.

**The published 1.2.4 (TV) and 1.1.3 (phone) APKs are unaffected** and do not need re-cutting: this was a defect in a test's own bookkeeping, not in anything that ships.

Verified locally with `:core:allTests :app-windows:test --rerun-tasks`, plus six consecutive forced reruns of the two affected classes.